### PR TITLE
Add user authentication, SQLite storage, and sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ server/uploads/
 .env
 *.log
 *.csv
+*.db
+*.db-wal
+*.db-shm
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,9 @@ COPY --from=build /app/server/dist server/dist
 # Copy built client
 COPY --from=build /app/client/dist client/dist
 
-# Auth state is stored here (mount as volume for persistence)
-VOLUME /app/auth_info
+# Data directory for SQLite database (mount as volume for persistence)
+RUN mkdir -p /app/data
+VOLUME /app/data
 
 ENV NODE_ENV=production
 ENV PORT=3001

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
+import { getToken, clearAuth } from './lib/auth';
+import { LoginPage } from './components/LoginPage';
+import { Sidebar } from './components/Sidebar';
+import type { Page } from './components/Sidebar';
 import { useSocket } from './hooks/useSocket';
-import { Stepper } from './components/Stepper';
 import { AuthStep } from './components/AuthStep';
 import { UploadStep } from './components/UploadStep';
 import { TemplateStep } from './components/TemplateStep';
@@ -8,75 +11,103 @@ import { PreviewStep } from './components/PreviewStep';
 import { BlastStep } from './components/BlastStep';
 import type { Contact } from './lib/api';
 
-function App() {
+const PAGE_TITLES: Record<Page, string> = {
+  connect: 'Connect WhatsApp',
+  upload: 'Upload Contacts',
+  template: 'Message Template',
+  preview: 'Preview Messages',
+  send: 'Send Messages',
+};
+
+function Dashboard() {
   const socket = useSocket();
-  const [step, setStep] = useState(1);
+  const [page, setPage] = useState<Page>('connect');
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [template, setTemplate] = useState('');
 
+  const handleLogout = () => {
+    clearAuth();
+    window.location.reload();
+  };
+
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-center text-gray-800 mb-2">
-          WA Blast
-        </h1>
-        <p className="text-center text-gray-500 mb-8">
-          Send personalized WhatsApp messages at scale
-        </p>
+    <div className="flex min-h-screen bg-gray-50">
+      <Sidebar
+        currentPage={page}
+        onNavigate={setPage}
+        onLogout={handleLogout}
+        onCollapse={() => setSidebarCollapsed(!sidebarCollapsed)}
+        collapsed={sidebarCollapsed}
+        socket={socket}
+      />
 
-        <Stepper currentStep={step} />
+      <main className="flex-1 p-8">
+        <div className="max-w-3xl mx-auto">
+          <h2 className="text-2xl font-bold text-gray-800 mb-6">{PAGE_TITLES[page]}</h2>
 
-        <div className="bg-white rounded-xl shadow-sm border p-8">
-          {step === 1 && (
-            <AuthStep socket={socket} onNext={() => setStep(2)} />
-          )}
-          {step === 2 && (
-            <UploadStep
-              onNext={(c) => {
-                setContacts(c);
-                setStep(3);
-              }}
-              onBack={() => setStep(1)}
-            />
-          )}
-          {step === 3 && (
-            <TemplateStep
-              contacts={contacts}
-              onNext={(t) => {
-                setTemplate(t);
-                setStep(4);
-              }}
-              onBack={() => setStep(2)}
-            />
-          )}
-          {step === 4 && (
-            <PreviewStep
-              contacts={contacts}
-              template={template}
-              onConfirm={() => setStep(5)}
-              onBack={() => setStep(3)}
-            />
-          )}
-          {step === 5 && (
-            <BlastStep
-              socket={socket}
-              contacts={contacts}
-              template={template}
-              onReset={() => {
-                setContacts([]);
-                setTemplate('');
-                setStep(2);
-              }}
-            />
-          )}
+          <div className="bg-white rounded-xl shadow-sm border p-8">
+            {page === 'connect' && (
+              <AuthStep socket={socket} onNext={() => setPage('upload')} />
+            )}
+            {page === 'upload' && (
+              <UploadStep
+                onNext={(c) => {
+                  setContacts(c);
+                  setPage('template');
+                }}
+                onBack={() => setPage('connect')}
+              />
+            )}
+            {page === 'template' && (
+              <TemplateStep
+                contacts={contacts}
+                onNext={(t) => {
+                  setTemplate(t);
+                  setPage('preview');
+                }}
+                onBack={() => setPage('upload')}
+              />
+            )}
+            {page === 'preview' && (
+              <PreviewStep
+                contacts={contacts}
+                template={template}
+                onConfirm={() => setPage('send')}
+                onBack={() => setPage('template')}
+              />
+            )}
+            {page === 'send' && (
+              <BlastStep
+                socket={socket}
+                contacts={contacts}
+                template={template}
+                onReset={() => {
+                  setContacts([]);
+                  setTemplate('');
+                  setPage('upload');
+                }}
+              />
+            )}
+          </div>
+
+          <footer className="text-center text-gray-400 text-sm mt-8 pb-4">
+            Created by Raihan Afiandi
+          </footer>
         </div>
-
-        <footer className="text-center text-gray-400 text-sm mt-8 pb-4">
-          Created by Raihan Afiandi
-        </footer>
-      </div>
+      </main>
     </div>
   );
+}
+
+function App() {
+  const [authed, setAuthed] = useState(!!getToken());
+
+  if (!authed) {
+    return <LoginPage onAuth={() => setAuthed(true)} />;
+  }
+
+  return <Dashboard />;
 }
 
 export default App;

--- a/client/src/components/AuthStep.tsx
+++ b/client/src/components/AuthStep.tsx
@@ -47,7 +47,6 @@ export function AuthStep({ socket, onNext }: AuthStepProps) {
 
   return (
     <div className="flex flex-col items-center gap-6">
-      <h2 className="text-2xl font-semibold text-gray-800">Connect WhatsApp</h2>
       <p className="text-gray-500">Scan the QR code with your WhatsApp to get started</p>
 
       <div className="w-72 h-72 border border-gray-200 rounded-xl flex items-center justify-center bg-white shadow-sm">

--- a/client/src/components/LoginPage.tsx
+++ b/client/src/components/LoginPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import { login, register } from '../lib/auth';
+
+interface LoginPageProps {
+  onAuth: () => void;
+}
+
+export function LoginPage({ onAuth }: LoginPageProps) {
+  const [isRegister, setIsRegister] = useState(false);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      if (isRegister) {
+        await register(username, password);
+      } else {
+        await login(username, password);
+      }
+      onAuth();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-gray-800">WA Blast</h1>
+          <p className="text-gray-500 mt-2">
+            {isRegister ? 'Create an account' : 'Sign in to continue'}
+          </p>
+        </div>
+
+        <div className="bg-white rounded-xl shadow-sm border p-6">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
+                Username
+              </label>
+              <input
+                id="username"
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-800 focus:border-transparent"
+                placeholder="Enter username"
+                required
+                autoFocus
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                Password
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-gray-800 focus:border-transparent"
+                placeholder="Enter password"
+                required
+              />
+            </div>
+
+            {error && (
+              <div className="bg-red-50 border border-red-200 text-red-600 text-sm rounded-lg px-3 py-2">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-2.5 bg-gray-800 text-white rounded-lg font-medium text-sm hover:bg-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? 'Please wait...' : isRegister ? 'Create Account' : 'Sign In'}
+            </button>
+          </form>
+
+          <div className="mt-4 text-center">
+            <button
+              onClick={() => {
+                setIsRegister(!isRegister);
+                setError('');
+              }}
+              className="text-sm text-gray-500 hover:text-gray-800 transition-colors"
+            >
+              {isRegister ? 'Already have an account? Sign in' : "Don't have an account? Register"}
+            </button>
+          </div>
+        </div>
+
+        <footer className="text-center text-gray-400 text-sm mt-8">
+          Created by Raihan Afiandi
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,0 +1,228 @@
+import type { Socket } from 'socket.io-client';
+import { useEffect, useState } from 'react';
+import { getUser } from '../lib/auth';
+
+const BLAST_PAGES = [
+  { id: 'upload', label: 'Upload Contacts', icon: 'M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12' },
+  { id: 'template', label: 'Template', icon: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z' },
+  { id: 'preview', label: 'Preview', icon: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z' },
+  { id: 'send', label: 'Send', icon: 'M12 19l9 2-9-18-9 18 9-2zm0 0v-8' },
+];
+
+export type Page = 'connect' | 'upload' | 'template' | 'preview' | 'send';
+
+interface SidebarProps {
+  currentPage: Page;
+  onNavigate: (page: Page) => void;
+  onLogout: () => void;
+  onCollapse: () => void;
+  collapsed: boolean;
+  socket: Socket;
+}
+
+export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collapsed, socket }: SidebarProps) {
+  const [waStatus, setWaStatus] = useState<string>('disconnected');
+  const [blastOpen, setBlastOpen] = useState(true);
+
+  useEffect(() => {
+    const onStatus = (s: string) => setWaStatus(s);
+    socket.on('status', onStatus);
+    return () => { socket.off('status', onStatus); };
+  }, [socket]);
+
+  const isConnected = waStatus === 'connected';
+
+  const statusColor =
+    waStatus === 'connected' ? 'bg-green-500' :
+    waStatus === 'qr_pending' ? 'bg-yellow-500' :
+    waStatus === 'error' ? 'bg-red-500' :
+    'bg-gray-400';
+
+  const statusLabel =
+    waStatus === 'connected' ? 'Connected' :
+    waStatus === 'qr_pending' ? 'Waiting for QR' :
+    waStatus === 'error' ? 'Error' :
+    'Disconnected';
+
+  if (collapsed) {
+    return (
+      <aside className="w-16 bg-white border-r border-gray-200 flex flex-col min-h-screen items-center py-4">
+        <button
+          onClick={onCollapse}
+          className="p-2 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors mb-4"
+          title="Expand sidebar"
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+          </svg>
+        </button>
+
+        <div className="flex-1 flex flex-col items-center gap-2">
+          <button
+            onClick={() => onNavigate('connect')}
+            className={`p-2 rounded-lg transition-colors ${currentPage === 'connect' ? 'bg-gray-900 text-white' : 'text-gray-400 hover:bg-gray-100 hover:text-gray-600'}`}
+            title="Connect"
+          >
+            <span className={`block w-2 h-2 rounded-full ${statusColor}`} />
+          </button>
+
+          {BLAST_PAGES.map((p) => {
+            const disabled = !isConnected;
+            const isActive = currentPage === p.id;
+            return (
+              <button
+                key={p.id}
+                onClick={() => !disabled && onNavigate(p.id as Page)}
+                disabled={disabled}
+                className={`p-2 rounded-lg transition-colors ${
+                  isActive ? 'bg-gray-900 text-white' :
+                  disabled ? 'text-gray-300 cursor-not-allowed' :
+                  'text-gray-400 hover:bg-gray-100 hover:text-gray-600'
+                }`}
+                title={disabled ? `${p.label} (connect first)` : p.label}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d={p.icon} />
+                </svg>
+              </button>
+            );
+          })}
+        </div>
+
+        <button
+          onClick={onLogout}
+          className="p-2 text-gray-400 hover:text-red-500 transition-colors"
+          title="Logout"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
+        </button>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="w-64 bg-white border-r border-gray-200 flex flex-col min-h-screen">
+      {/* Header */}
+      <div className="p-6 border-b border-gray-100 flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold text-gray-800">WA Blast</h1>
+          <p className="text-xs text-gray-400 mt-1">Message blaster</p>
+        </div>
+        <button
+          onClick={onCollapse}
+          className="p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+          title="Collapse sidebar"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+          </svg>
+        </button>
+      </div>
+
+      {/* WA Status */}
+      <button
+        onClick={() => onNavigate('connect')}
+        className={`mx-3 mt-4 px-4 py-3 rounded-lg border text-left transition-colors ${
+          currentPage === 'connect'
+            ? 'bg-gray-900 border-gray-900'
+            : 'bg-gray-50 border-gray-100 hover:bg-gray-100'
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <span className={`w-2 h-2 rounded-full ${statusColor}`} />
+          <span className={`text-xs font-medium ${currentPage === 'connect' ? 'text-white' : 'text-gray-600'}`}>
+            WhatsApp
+          </span>
+        </div>
+        <p className={`text-xs mt-1 ml-4 ${currentPage === 'connect' ? 'text-gray-400' : 'text-gray-400'}`}>
+          {statusLabel}
+        </p>
+      </button>
+
+      {/* Navigation */}
+      <nav className="flex-1 px-3 mt-6">
+        {/* Blast dropdown */}
+        <button
+          onClick={() => setBlastOpen(!blastOpen)}
+          className="w-full flex items-center justify-between px-3 py-2 text-[10px] font-semibold text-gray-400 uppercase tracking-wider hover:text-gray-600 transition-colors"
+        >
+          <span>Blast</span>
+          <svg
+            className={`w-3 h-3 transition-transform ${blastOpen ? 'rotate-0' : '-rotate-90'}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {blastOpen && (
+          <ul className="space-y-1 mt-1">
+            {BLAST_PAGES.map((p) => {
+              const disabled = !isConnected;
+              const isActive = currentPage === p.id;
+
+              return (
+                <li key={p.id}>
+                  <button
+                    onClick={() => !disabled && onNavigate(p.id as Page)}
+                    disabled={disabled}
+                    className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
+                      isActive
+                        ? 'bg-gray-900 text-white'
+                        : disabled
+                          ? 'text-gray-300 cursor-not-allowed'
+                          : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                  >
+                    <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d={p.icon} />
+                    </svg>
+                    <span>{p.label}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </nav>
+
+      {/* Settings */}
+      <div className="px-3 mb-2">
+        <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider px-3 mb-2">Settings</p>
+        <button
+          onClick={() => onNavigate('connect')}
+          className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
+            currentPage === 'connect' ? 'text-gray-900 bg-gray-100' : 'text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          <span>WA Connection</span>
+        </button>
+      </div>
+
+      {/* User */}
+      <div className="border-t border-gray-100 p-4 flex items-center gap-3">
+        <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-sm font-medium text-gray-600">
+          {(getUser() || '?')[0].toUpperCase()}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-gray-700 truncate">{getUser()}</p>
+        </div>
+        <button
+          onClick={onLogout}
+          className="text-gray-400 hover:text-red-500 transition-colors"
+          title="Logout"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -1,15 +1,20 @@
 import { useEffect, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
+import { getToken } from '../lib/auth';
 
 export function useSocket() {
   const socketRef = useRef<Socket | null>(null);
 
   if (!socketRef.current) {
-    socketRef.current = io('/', { autoConnect: false });
+    socketRef.current = io('/', {
+      autoConnect: false,
+      auth: { token: getToken() },
+    });
   }
 
   useEffect(() => {
     const socket = socketRef.current!;
+    socket.auth = { token: getToken() };
     socket.connect();
     return () => {
       socket.disconnect();

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { getToken } from './auth';
+
 export interface Contact {
   name: string;
   number: string;
@@ -9,10 +11,22 @@ export interface UploadResult {
   errors: string[];
 }
 
+function authHeaders(extra?: Record<string, string>): Record<string, string> {
+  const token = getToken();
+  return {
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...extra,
+  };
+}
+
 export async function uploadFile(file: File): Promise<UploadResult> {
   const formData = new FormData();
   formData.append('file', file);
-  const res = await fetch('/api/upload', { method: 'POST', body: formData });
+  const res = await fetch('/api/upload', {
+    method: 'POST',
+    headers: authHeaders(),
+    body: formData,
+  });
   if (!res.ok) {
     const err = await res.json();
     throw new Error(err.error || 'Upload failed');
@@ -23,7 +37,7 @@ export async function uploadFile(file: File): Promise<UploadResult> {
 export async function startBlast(contacts: Contact[], template: string) {
   const res = await fetch('/api/blast', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: authHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ contacts, template }),
   });
   if (!res.ok) {

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,0 +1,50 @@
+const TOKEN_KEY = 'wa-blast-token';
+const USER_KEY = 'wa-blast-user';
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function getUser(): string | null {
+  return localStorage.getItem(USER_KEY);
+}
+
+export function setAuth(token: string, username: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(USER_KEY, username);
+}
+
+export function clearAuth(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+}
+
+export async function login(username: string, password: string): Promise<{ token: string; username: string }> {
+  const res = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error || 'Login failed');
+  }
+  const data = await res.json();
+  setAuth(data.token, data.username);
+  return data;
+}
+
+export async function register(username: string, password: string): Promise<{ token: string; username: string }> {
+  const res = await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error || 'Registration failed');
+  }
+  const data = await res.json();
+  setAuth(data.token, data.username);
+  return data;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,12 @@ services:
     ports:
       - "8543:8543"
     volumes:
-      - wa_auth:/app/auth_info
+      - wa_data:/app/data
     environment:
       - PORT=8543
+      - DB_PATH=/app/data/wa-blast.db
+      - JWT_SECRET=${JWT_SECRET:-change-me-in-production}
     restart: unless-stopped
 
 volumes:
-  wa_auth:
+  wa_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1789,6 +1789,23 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1863,10 +1880,28 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/multer": {
@@ -2634,6 +2669,87 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -2740,6 +2856,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2909,6 +3031,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/client": {
       "resolved": "client",
@@ -3151,6 +3279,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3189,7 +3341,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3213,6 +3364,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -3241,6 +3401,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -3675,6 +3844,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -3811,6 +3989,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -3952,6 +4136,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4044,6 +4234,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -4264,6 +4460,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4385,6 +4587,61 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -4751,10 +5008,52 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -4864,6 +5163,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -4896,6 +5207,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mpg123-decoder": {
       "version": "1.0.3",
@@ -4976,6 +5293,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4989,6 +5312,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-releases": {
@@ -5063,6 +5410,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -5292,6 +5648,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5394,6 +5777,16 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5609,6 +6002,30 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -6034,6 +6451,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-yenc": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-1.0.4.tgz",
@@ -6285,6 +6747,48 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -6382,6 +6886,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -6701,6 +7217,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -6847,8 +7369,11 @@
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@whiskeysockets/baileys": "^6.17.16",
+        "bcryptjs": "^3.0.3",
+        "better-sqlite3": "^12.8.0",
         "cors": "^2.8.5",
         "express": "^4.21.0",
+        "jsonwebtoken": "^9.0.3",
         "multer": "^1.4.5-lts.1",
         "papaparse": "^5.4.1",
         "qrcode": "^1.5.4",
@@ -6856,8 +7381,11 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/multer": "^1.4.12",
         "@types/papaparse": "^5.3.15",
         "@types/qrcode": "^1.5.5",

--- a/server/package.json
+++ b/server/package.json
@@ -11,8 +11,11 @@
   "dependencies": {
     "@hapi/boom": "^10.0.1",
     "@whiskeysockets/baileys": "^6.17.16",
+    "bcryptjs": "^3.0.3",
+    "better-sqlite3": "^12.8.0",
     "cors": "^2.8.5",
     "express": "^4.21.0",
+    "jsonwebtoken": "^9.0.3",
     "multer": "^1.4.5-lts.1",
     "papaparse": "^5.4.1",
     "qrcode": "^1.5.4",
@@ -20,8 +23,11 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^1.4.12",
     "@types/papaparse": "^5.3.15",
     "@types/qrcode": "^1.5.5",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,5 +1,8 @@
 export const SERVER_PORT = process.env.PORT ? parseInt(process.env.PORT) : 3001;
 
+export const JWT_SECRET = process.env.JWT_SECRET || 'wa-blast-dev-secret-change-in-prod';
+export const JWT_EXPIRES_IN = '7d';
+
 export const UPLOAD_MAX_SIZE = 5 * 1024 * 1024; // 5MB
 
 export const DEFAULT_COUNTRY_CODE = '62'; // Indonesia

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,0 +1,29 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, '../../wa-blast.db');
+
+const db: InstanceType<typeof Database> = new Database(DB_PATH);
+
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS wa_auth (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`);
+
+console.log('[DB] SQLite initialized at', DB_PATH);
+
+export default db;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,18 @@ import cors from 'cors';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { SERVER_PORT } from './config.js';
-import { initSession, logout, getStatus } from './whatsapp/session.js';
+import './db.js';
+import { initSession, disconnect, getStatus } from './whatsapp/session.js';
+
+// Prevent Baileys background tasks from crashing the process
+process.on('uncaughtException', (err) => {
+  console.error('[Process] Uncaught exception:', err.message);
+});
+process.on('unhandledRejection', (err) => {
+  console.error('[Process] Unhandled rejection:', err);
+});
+import { requireAuth, verifySocketToken } from './middleware/auth.js';
+import authRouter from './routes/auth.js';
 import uploadRouter from './routes/upload.js';
 import templateRouter from './routes/template.js';
 import { createBlastRouter } from './routes/blast.js';
@@ -21,12 +32,15 @@ const io = new Server(httpServer, {
 app.use(cors());
 app.use(express.json());
 
-// REST routes
-app.use('/api/upload', uploadRouter);
-app.use('/api/template', templateRouter);
-app.use('/api/blast', createBlastRouter(io));
+// Public routes
+app.use('/api/auth', authRouter);
 
-app.get('/api/status', (_req, res) => {
+// Protected routes
+app.use('/api/upload', requireAuth, uploadRouter);
+app.use('/api/template', requireAuth, templateRouter);
+app.use('/api/blast', requireAuth, createBlastRouter(io));
+
+app.get('/api/status', requireAuth, (_req, res) => {
   res.json({ status: getStatus() });
 });
 
@@ -37,11 +51,24 @@ app.get('*', (_req, res) => {
   res.sendFile(path.join(clientDist, 'index.html'));
 });
 
-// Socket.IO
+// Socket.IO with auth
+io.use((socket, next) => {
+  const token = socket.handshake.auth.token as string | undefined;
+  if (!token) {
+    next(new Error('Authentication required'));
+    return;
+  }
+  const user = verifySocketToken(token);
+  if (!user) {
+    next(new Error('Invalid token'));
+    return;
+  }
+  (socket as unknown as { user: typeof user }).user = user;
+  next();
+});
+
 io.on('connection', (socket) => {
   console.log('Client connected:', socket.id);
-
-  // Send current status on connect
   socket.emit('status', getStatus());
 
   socket.on('connect-wa', async () => {
@@ -55,7 +82,7 @@ io.on('connection', (socket) => {
 
   socket.on('disconnect-wa', async () => {
     try {
-      await logout(io);
+      await disconnect(io);
     } catch (err) {
       console.error('Failed to logout:', err);
     }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,31 @@
+import type { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '../config.js';
+
+export interface AuthRequest extends Request {
+  user?: { id: number; username: string };
+}
+
+export function requireAuth(req: AuthRequest, res: Response, next: NextFunction): void {
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Authentication required' });
+    return;
+  }
+
+  try {
+    const payload = jwt.verify(header.slice(7), JWT_SECRET) as { id: number; username: string };
+    req.user = payload;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired token' });
+  }
+}
+
+export function verifySocketToken(token: string): { id: number; username: string } | null {
+  try {
+    return jwt.verify(token, JWT_SECRET) as { id: number; username: string };
+  } catch {
+    return null;
+  }
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,67 @@
+import { Router } from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import db from '../db.js';
+import { JWT_SECRET, JWT_EXPIRES_IN } from '../config.js';
+
+const router = Router();
+
+router.post('/register', (req, res) => {
+  const { username, password } = req.body;
+
+  if (!username || !password) {
+    res.status(400).json({ error: 'Username and password are required' });
+    return;
+  }
+
+  if (username.length < 3) {
+    res.status(400).json({ error: 'Username must be at least 3 characters' });
+    return;
+  }
+
+  if (password.length < 6) {
+    res.status(400).json({ error: 'Password must be at least 6 characters' });
+    return;
+  }
+
+  const existing = db.prepare('SELECT id FROM users WHERE username = ?').get(username);
+  if (existing) {
+    res.status(409).json({ error: 'Username already taken' });
+    return;
+  }
+
+  const hash = bcrypt.hashSync(password, 10);
+  const result = db.prepare('INSERT INTO users (username, password) VALUES (?, ?)').run(username, hash);
+
+  const token = jwt.sign({ id: result.lastInsertRowid, username }, JWT_SECRET, {
+    expiresIn: JWT_EXPIRES_IN,
+  });
+
+  res.status(201).json({ token, username });
+});
+
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+
+  if (!username || !password) {
+    res.status(400).json({ error: 'Username and password are required' });
+    return;
+  }
+
+  const user = db.prepare('SELECT id, username, password FROM users WHERE username = ?').get(username) as
+    | { id: number; username: string; password: string }
+    | undefined;
+
+  if (!user || !bcrypt.compareSync(password, user.password)) {
+    res.status(401).json({ error: 'Invalid username or password' });
+    return;
+  }
+
+  const token = jwt.sign({ id: user.id, username: user.username }, JWT_SECRET, {
+    expiresIn: JWT_EXPIRES_IN,
+  });
+
+  res.json({ token, username: user.username });
+});
+
+export default router;

--- a/server/src/whatsapp/authState.ts
+++ b/server/src/whatsapp/authState.ts
@@ -1,0 +1,74 @@
+import { WAProto, initAuthCreds, BufferJSON } from '@whiskeysockets/baileys';
+import type { AuthenticationCreds, AuthenticationState, SignalDataTypeMap } from '@whiskeysockets/baileys';
+import db from '../db.js';
+
+const getStmt = db.prepare('SELECT value FROM wa_auth WHERE key = ?');
+const setStmt = db.prepare('INSERT OR REPLACE INTO wa_auth (key, value) VALUES (?, ?)');
+const delStmt = db.prepare('DELETE FROM wa_auth WHERE key = ?');
+const delPrefixStmt = db.prepare('DELETE FROM wa_auth WHERE key LIKE ?');
+
+function readData(key: string): unknown | null {
+  const row = getStmt.get(key) as { value: string } | undefined;
+  if (!row) return null;
+  return JSON.parse(row.value, BufferJSON.reviver);
+}
+
+function writeData(key: string, data: unknown): void {
+  const value = JSON.stringify(data, BufferJSON.replacer);
+  setStmt.run(key, value);
+}
+
+function removeData(key: string): void {
+  delStmt.run(key);
+}
+
+export function useSQLiteAuthState(): { state: AuthenticationState; saveCreds: () => void } {
+  const creds: AuthenticationCreds = (readData('creds') as AuthenticationCreds) || initAuthCreds();
+
+  const state: AuthenticationState = {
+    creds,
+    keys: {
+      get: <T extends keyof SignalDataTypeMap>(type: T, ids: string[]) => {
+        const data: { [id: string]: SignalDataTypeMap[T] } = {};
+        for (const id of ids) {
+          const value = readData(`${type}-${id}`);
+          if (value) {
+            if (type === 'app-state-sync-key') {
+              data[id] = WAProto.Message.AppStateSyncKeyData.fromObject(value) as unknown as SignalDataTypeMap[T];
+            } else {
+              data[id] = value as SignalDataTypeMap[T];
+            }
+          }
+        }
+        return data;
+      },
+      set: (data) => {
+        const transaction = db.transaction(() => {
+          for (const category in data) {
+            for (const id in data[category as keyof SignalDataTypeMap]) {
+              const value = data[category as keyof SignalDataTypeMap]![id];
+              const key = `${category}-${id}`;
+              if (value) {
+                writeData(key, value);
+              } else {
+                removeData(key);
+              }
+            }
+          }
+        });
+        transaction();
+      },
+    },
+  };
+
+  const saveCreds = (): void => {
+    writeData('creds', state.creds);
+  };
+
+  return { state, saveCreds };
+}
+
+export function clearSQLiteAuthState(): void {
+  delPrefixStmt.run('%');
+  console.log('[WA] Cleared SQLite auth state');
+}

--- a/server/src/whatsapp/session.ts
+++ b/server/src/whatsapp/session.ts
@@ -1,15 +1,13 @@
 import {
   makeWASocket,
-  useMultiFileAuthState,
   DisconnectReason,
 } from '@whiskeysockets/baileys';
 import { Boom } from '@hapi/boom';
-import { rm } from 'fs/promises';
 import QRCode from 'qrcode';
 import type { Server as SocketIOServer } from 'socket.io';
 import type { WAStatus } from '../types.js';
+import { useSQLiteAuthState, clearSQLiteAuthState } from './authState.js';
 
-const AUTH_DIR = './auth_info';
 const MAX_RETRIES = 3;
 const WA_VERSION: [number, number, number] = [2, 3000, 1034195523];
 
@@ -25,15 +23,6 @@ export function getSocket(): typeof sock {
 
 export function getStatus(): WAStatus {
   return status;
-}
-
-async function clearAuthState(): Promise<void> {
-  try {
-    await rm(AUTH_DIR, { recursive: true, force: true });
-    console.log('[WA] Cleared auth state');
-  } catch {
-    // ignore
-  }
 }
 
 export async function initSession(io: SocketIOServer): Promise<void> {
@@ -54,7 +43,7 @@ export async function initSession(io: SocketIOServer): Promise<void> {
   console.log('[WA] Initializing session... (attempt', retryCount + 1, ')');
 
   try {
-    const { state, saveCreds } = await useMultiFileAuthState(AUTH_DIR);
+    const { state, saveCreds } = useSQLiteAuthState();
 
     sock = makeWASocket({
       auth: state,
@@ -98,7 +87,7 @@ export async function initSession(io: SocketIOServer): Promise<void> {
 
         if (shouldClearAuth) {
           console.log('[WA] Got', reason, '— clearing auth state and retrying fresh');
-          await clearAuthState();
+          clearSQLiteAuthState();
         }
 
         retryCount++;
@@ -124,12 +113,18 @@ export async function initSession(io: SocketIOServer): Promise<void> {
   }
 }
 
-export async function logout(io: SocketIOServer): Promise<void> {
+export async function disconnect(io: SocketIOServer): Promise<void> {
   if (sock) {
-    await sock.logout();
+    sock.ev.removeAllListeners('connection.update');
+    sock.ev.removeAllListeners('creds.update');
+    try {
+      sock.end(undefined);
+    } catch {
+      // ignore — background tasks may throw on closed connection
+    }
     sock = null;
   }
-  await clearAuthState();
+  clearSQLiteAuthState();
   initializing = false;
   retryCount = 0;
   status = 'disconnected';


### PR DESCRIPTION
## Summary

- Multi-user registration and login with JWT authentication
- SQLite database (`better-sqlite3`) for user accounts and Baileys auth state, replacing file-based `auth_info/`
- Sidebar navigation with collapsible "Blast" dropdown, WA connection status, and collapse/expand toggle
- Menu items greyed out and disabled when WhatsApp is not connected
- Fix disconnect crash caused by `sock.logout()` conflicting with Baileys background tasks

## Test plan

- [x] Register a new user, verify login works
- [x] Verify JWT protects all API routes and Socket.IO (401 without token)
- [x] Connect WhatsApp via QR, verify sidebar status updates
- [x] Verify blast menu items are disabled until connected
- [x] Disconnect WA, verify no server crash
- [x] Collapse/expand sidebar
- [x] Docker build and run with SQLite volume persistence