### PR TITLE
feat: custom template variables, manual contacts, saved templates & blast history

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import { UploadStep } from './components/UploadStep';
 import { TemplateStep } from './components/TemplateStep';
 import { PreviewStep } from './components/PreviewStep';
 import { BlastStep } from './components/BlastStep';
+import { HistoryPage } from './components/HistoryPage';
 import type { Contact } from './lib/api';
 
 const PAGE_TITLES: Record<Page, string> = {
@@ -17,6 +18,7 @@ const PAGE_TITLES: Record<Page, string> = {
   template: 'Message Template',
   preview: 'Preview Messages',
   send: 'Send Messages',
+  history: 'Blast History',
 };
 
 function Dashboard() {
@@ -24,6 +26,7 @@ function Dashboard() {
   const [page, setPage] = useState<Page>('connect');
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [contacts, setContacts] = useState<Contact[]>([]);
+  const [columns, setColumns] = useState<string[]>(['name']);
   const [template, setTemplate] = useState('');
 
   const handleLogout = () => {
@@ -52,8 +55,9 @@ function Dashboard() {
             )}
             {page === 'upload' && (
               <UploadStep
-                onNext={(c) => {
+                onNext={(c, cols) => {
                   setContacts(c);
+                  setColumns(cols);
                   setPage('template');
                 }}
                 onBack={() => setPage('connect')}
@@ -62,6 +66,7 @@ function Dashboard() {
             {page === 'template' && (
               <TemplateStep
                 contacts={contacts}
+                columns={columns}
                 onNext={(t) => {
                   setTemplate(t);
                   setPage('preview');
@@ -72,6 +77,7 @@ function Dashboard() {
             {page === 'preview' && (
               <PreviewStep
                 contacts={contacts}
+                columns={columns}
                 template={template}
                 onConfirm={() => setPage('send')}
                 onBack={() => setPage('template')}
@@ -84,10 +90,14 @@ function Dashboard() {
                 template={template}
                 onReset={() => {
                   setContacts([]);
+                  setColumns(['name']);
                   setTemplate('');
                   setPage('upload');
                 }}
               />
+            )}
+            {page === 'history' && (
+              <HistoryPage />
             )}
           </div>
 

--- a/client/src/components/HistoryPage.tsx
+++ b/client/src/components/HistoryPage.tsx
@@ -1,0 +1,160 @@
+import { useState, useEffect } from 'react';
+import { getHistory, getHistoryDetail, type BlastHistorySummary, type BlastRecipientDetail } from '../lib/api';
+
+export function HistoryPage() {
+  const [history, setHistory] = useState<BlastHistorySummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedBlast, setSelectedBlast] = useState<BlastHistorySummary | null>(null);
+  const [recipients, setRecipients] = useState<BlastRecipientDetail[]>([]);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  useEffect(() => {
+    getHistory()
+      .then(setHistory)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const viewDetail = async (blast: BlastHistorySummary) => {
+    if (selectedBlast?.id === blast.id) {
+      setSelectedBlast(null);
+      setRecipients([]);
+      return;
+    }
+    setSelectedBlast(blast);
+    setDetailLoading(true);
+    try {
+      const data = await getHistoryDetail(blast.id);
+      setRecipients(data.recipients);
+    } catch {
+      setRecipients([]);
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const statusBadge = (status: string) => {
+    const colors = {
+      running: 'bg-blue-100 text-blue-700',
+      completed: 'bg-green-100 text-green-700',
+      error: 'bg-red-100 text-red-700',
+    };
+    return colors[status as keyof typeof colors] || 'bg-gray-100 text-gray-700';
+  };
+
+  const recipientBadge = (status: string) => {
+    const colors = {
+      pending: 'text-gray-500',
+      sent: 'text-green-600',
+      failed: 'text-red-600',
+    };
+    return colors[status as keyof typeof colors] || 'text-gray-500';
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-gray-400">Loading history...</div>
+      </div>
+    );
+  }
+
+  if (history.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+        <svg className="w-12 h-12 mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <p>No blast history yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {history.map((blast) => (
+        <div key={blast.id} className="border rounded-lg overflow-hidden">
+          <button
+            onClick={() => viewDetail(blast)}
+            className="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left"
+          >
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-3 mb-1">
+                <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${statusBadge(blast.status)}`}>
+                  {blast.status}
+                </span>
+                <span className="text-xs text-gray-400">
+                  {new Date(blast.started_at).toLocaleString()}
+                </span>
+              </div>
+              <p className="text-sm text-gray-700 truncate max-w-md">
+                {blast.template.slice(0, 80)}{blast.template.length > 80 ? '...' : ''}
+              </p>
+            </div>
+            <div className="flex items-center gap-4 ml-4 shrink-0">
+              <div className="text-center">
+                <p className="text-sm font-semibold text-green-600">{blast.sent}</p>
+                <p className="text-xs text-gray-400">Sent</p>
+              </div>
+              <div className="text-center">
+                <p className="text-sm font-semibold text-red-500">{blast.failed}</p>
+                <p className="text-xs text-gray-400">Failed</p>
+              </div>
+              <div className="text-center">
+                <p className="text-sm font-semibold text-gray-600">{blast.total}</p>
+                <p className="text-xs text-gray-400">Total</p>
+              </div>
+              <svg
+                className={`w-4 h-4 text-gray-400 transition-transform ${selectedBlast?.id === blast.id ? 'rotate-180' : ''}`}
+                fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          </button>
+
+          {selectedBlast?.id === blast.id && (
+            <div className="border-t bg-gray-50 p-4">
+              {detailLoading ? (
+                <p className="text-gray-400 text-sm text-center py-4">Loading details...</p>
+              ) : recipients.length === 0 ? (
+                <p className="text-gray-400 text-sm text-center py-4">No recipient data available.</p>
+              ) : (
+                <div className="max-h-64 overflow-auto">
+                  <table className="w-full text-sm text-left">
+                    <thead className="bg-white sticky top-0">
+                      <tr>
+                        <th className="px-3 py-2 text-gray-500 text-xs">Number</th>
+                        <th className="px-3 py-2 text-gray-500 text-xs">Name</th>
+                        <th className="px-3 py-2 text-gray-500 text-xs">Status</th>
+                        <th className="px-3 py-2 text-gray-500 text-xs">Message</th>
+                        <th className="px-3 py-2 text-gray-500 text-xs">Error</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {recipients.map((r) => (
+                        <tr key={r.id} className="border-t border-gray-100">
+                          <td className="px-3 py-1.5 font-mono text-xs">{r.number}</td>
+                          <td className="px-3 py-1.5">{r.variables.name || '-'}</td>
+                          <td className={`px-3 py-1.5 font-medium text-xs ${recipientBadge(r.status)}`}>
+                            {r.status}
+                          </td>
+                          <td className="px-3 py-1.5 text-gray-600 max-w-xs truncate">
+                            {r.rendered_message || '-'}
+                          </td>
+                          <td className="px-3 py-1.5 text-red-500 text-xs max-w-xs truncate">
+                            {r.error || '-'}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/PreviewStep.tsx
+++ b/client/src/components/PreviewStep.tsx
@@ -3,50 +3,58 @@ import type { Contact } from '../lib/api';
 
 interface PreviewStepProps {
   contacts: Contact[];
+  columns: string[];
   template: string;
   onConfirm: () => void;
   onBack: () => void;
 }
 
-export function PreviewStep({ contacts, template, onConfirm, onBack }: PreviewStepProps) {
-  const [showModal, setShowModal] = useState(false);
+function renderMessage(template: string, variables: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key) => variables[key] ?? match);
+}
 
-  const renderMessage = (name: string) =>
-    template.replace(/\{name\}/g, name);
+export function PreviewStep({ contacts, columns, template, onConfirm, onBack }: PreviewStepProps) {
+  const [showModal, setShowModal] = useState(false);
 
   const estimatedSeconds = contacts.length * 2.25;
   const estimatedMinutes = Math.ceil(estimatedSeconds / 60);
 
   return (
     <div className="flex flex-col items-center gap-6">
-      <h2 className="text-2xl font-semibold text-gray-800">Review & Confirm</h2>
       <p className="text-gray-500">
         Review your messages before sending. {contacts.length} message{contacts.length !== 1 ? 's' : ''} will be sent.
         Estimated time: ~{estimatedMinutes} minute{estimatedMinutes !== 1 ? 's' : ''}.
       </p>
 
-      <div className="w-full max-w-2xl border rounded-lg overflow-hidden">
+      <div className="w-full max-w-3xl border rounded-lg overflow-hidden">
         <div className="max-h-80 overflow-y-auto">
           <table className="w-full text-sm text-left">
             <thead className="bg-gray-50 sticky top-0">
               <tr>
-                <th className="px-4 py-2 text-gray-600">#</th>
-                <th className="px-4 py-2 text-gray-600">Name</th>
-                <th className="px-4 py-2 text-gray-600">Number</th>
-                <th className="px-4 py-2 text-gray-600">Message Preview</th>
+                <th className="px-3 py-2 text-gray-600">#</th>
+                <th className="px-3 py-2 text-gray-600">Number</th>
+                {columns.map((col) => (
+                  <th key={col} className="px-3 py-2 text-gray-600 capitalize">{col}</th>
+                ))}
+                <th className="px-3 py-2 text-gray-600">Message Preview</th>
               </tr>
             </thead>
             <tbody>
-              {contacts.map((c, i) => (
-                <tr key={i} className="border-t">
-                  <td className="px-4 py-2 text-gray-400">{i + 1}</td>
-                  <td className="px-4 py-2">{c.name}</td>
-                  <td className="px-4 py-2 font-mono text-gray-600 text-xs">{c.number}</td>
-                  <td className="px-4 py-2 text-gray-700 max-w-xs truncate">
-                    {renderMessage(c.name)}
-                  </td>
-                </tr>
-              ))}
+              {contacts.map((c, i) => {
+                const { number, ...variables } = c;
+                return (
+                  <tr key={i} className="border-t">
+                    <td className="px-3 py-2 text-gray-400">{i + 1}</td>
+                    <td className="px-3 py-2 font-mono text-gray-600 text-xs">{number}</td>
+                    {columns.map((col) => (
+                      <td key={col} className="px-3 py-2">{c[col] || ''}</td>
+                    ))}
+                    <td className="px-3 py-2 text-gray-700 max-w-xs truncate">
+                      {renderMessage(template, variables)}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -67,7 +75,6 @@ export function PreviewStep({ contacts, template, onConfirm, onBack }: PreviewSt
         </button>
       </div>
 
-      {/* Confirmation Modal */}
       {showModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-xl p-6 max-w-md mx-4 shadow-xl">

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -3,10 +3,11 @@ import { useEffect, useState } from 'react';
 import { getUser } from '../lib/auth';
 
 const BLAST_PAGES = [
-  { id: 'upload', label: 'Upload Contacts', icon: 'M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12' },
-  { id: 'template', label: 'Template', icon: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z' },
-  { id: 'preview', label: 'Preview', icon: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z' },
-  { id: 'send', label: 'Send', icon: 'M12 19l9 2-9-18-9 18 9-2zm0 0v-8' },
+  { id: 'upload', label: 'Upload Contacts', icon: 'M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12', requiresWA: true },
+  { id: 'template', label: 'Template', icon: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z', requiresWA: true },
+  { id: 'preview', label: 'Preview', icon: 'M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z', requiresWA: true },
+  { id: 'send', label: 'Send', icon: 'M12 19l9 2-9-18-9 18 9-2zm0 0v-8', requiresWA: true },
+  { id: 'history', label: 'History', icon: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z', requiresWA: false },
 ];
 
 export type Page = 'connect' | 'upload' | 'template' | 'preview' | 'send' | 'history';
@@ -67,7 +68,7 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
           </button>
 
           {BLAST_PAGES.map((p) => {
-            const disabled = !isConnected;
+            const disabled = p.requiresWA && !isConnected;
             const isActive = currentPage === p.id;
             return (
               <button
@@ -87,16 +88,6 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
               </button>
             );
           })}
-
-          <button
-            onClick={() => onNavigate('history')}
-            className={`p-2 rounded-lg transition-colors ${currentPage === 'history' ? 'bg-gray-900 text-white' : 'text-gray-400 hover:bg-gray-100 hover:text-gray-600'}`}
-            title="History"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          </button>
         </div>
 
         <button
@@ -170,7 +161,7 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
         {blastOpen && (
           <ul className="space-y-1 mt-1">
             {BLAST_PAGES.map((p) => {
-              const disabled = !isConnected;
+              const disabled = p.requiresWA && !isConnected;
               const isActive = currentPage === p.id;
 
               return (
@@ -197,23 +188,6 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
           </ul>
         )}
       </nav>
-
-      {/* History — accessible without WA connection */}
-      <div className="px-3 mb-4">
-        <button
-          onClick={() => onNavigate('history')}
-          className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
-            currentPage === 'history'
-              ? 'bg-gray-900 text-white'
-              : 'text-gray-600 hover:bg-gray-100'
-          }`}
-        >
-          <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <span>History</span>
-        </button>
-      </div>
 
       {/* Settings */}
       <div className="px-3 mb-2">

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ const BLAST_PAGES = [
   { id: 'send', label: 'Send', icon: 'M12 19l9 2-9-18-9 18 9-2zm0 0v-8' },
 ];
 
-export type Page = 'connect' | 'upload' | 'template' | 'preview' | 'send';
+export type Page = 'connect' | 'upload' | 'template' | 'preview' | 'send' | 'history';
 
 interface SidebarProps {
   currentPage: Page;
@@ -87,6 +87,16 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
               </button>
             );
           })}
+
+          <button
+            onClick={() => onNavigate('history')}
+            className={`p-2 rounded-lg transition-colors ${currentPage === 'history' ? 'bg-gray-900 text-white' : 'text-gray-400 hover:bg-gray-100 hover:text-gray-600'}`}
+            title="History"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </button>
         </div>
 
         <button
@@ -187,6 +197,23 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
           </ul>
         )}
       </nav>
+
+      {/* History — accessible without WA connection */}
+      <div className="px-3 mb-4">
+        <button
+          onClick={() => onNavigate('history')}
+          className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
+            currentPage === 'history'
+              ? 'bg-gray-900 text-white'
+              : 'text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span>History</span>
+        </button>
+      </div>
 
       {/* Settings */}
       <div className="px-3 mb-2">

--- a/client/src/components/TemplateStep.tsx
+++ b/client/src/components/TemplateStep.tsx
@@ -1,52 +1,139 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import type { Contact } from '../lib/api';
+import { getTemplates, createTemplate, deleteTemplate, type SavedTemplate } from '../lib/api';
 
 interface TemplateStepProps {
   contacts: Contact[];
+  columns: string[];
   onNext: (template: string) => void;
   onBack: () => void;
 }
 
-export function TemplateStep({ contacts, onNext, onBack }: TemplateStepProps) {
+function renderPreview(template: string, variables: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key) => variables[key] ?? match);
+}
+
+export function TemplateStep({ contacts, columns, onNext, onBack }: TemplateStepProps) {
   const [template, setTemplate] = useState('');
+  const [savedTemplates, setSavedTemplates] = useState<SavedTemplate[]>([]);
+  const [saveName, setSaveName] = useState('');
+  const [showSave, setShowSave] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const preview = contacts.length > 0
-    ? template.replace(/\{name\}/g, contacts[0].name)
-    : template;
+  useEffect(() => {
+    getTemplates().then(setSavedTemplates).catch(() => {});
+  }, []);
 
-  const insertName = () => {
+  const firstContact = contacts[0] || {};
+  const { number: _, ...previewVars } = firstContact;
+  const preview = renderPreview(template, previewVars);
+
+  const insertVariable = (varName: string) => {
     const textarea = textareaRef.current;
     if (!textarea) return;
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
-    const newVal = template.slice(0, start) + '{name}' + template.slice(end);
+    const tag = `{${varName}}`;
+    const newVal = template.slice(0, start) + tag + template.slice(end);
     setTemplate(newVal);
     setTimeout(() => {
       textarea.focus();
-      textarea.setSelectionRange(start + 6, start + 6);
+      textarea.setSelectionRange(start + tag.length, start + tag.length);
     }, 0);
   };
 
-  const isValid = template.trim().length > 0 && template.includes('{name}');
+  const handleSaveTemplate = async () => {
+    if (!saveName.trim() || !template.trim()) return;
+    try {
+      const t = await createTemplate(saveName.trim(), template);
+      setSavedTemplates([t, ...savedTemplates]);
+      setSaveName('');
+      setShowSave(false);
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDeleteTemplate = async (id: number) => {
+    try {
+      await deleteTemplate(id);
+      setSavedTemplates(savedTemplates.filter((t) => t.id !== id));
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleLoadTemplate = (body: string) => {
+    setTemplate(body);
+  };
+
+  const isValid = template.trim().length > 0;
 
   return (
     <div className="flex flex-col items-center gap-6">
-      <h2 className="text-2xl font-semibold text-gray-800">Message Template</h2>
       <p className="text-gray-500">
-        Write your message. Use <code className="bg-gray-100 px-1.5 py-0.5 rounded text-green-700 text-sm">{'{name}'}</code> for the recipient's name.
+        Write your message. Use variable tags to personalize for each recipient.
       </p>
+
+      {/* Saved templates */}
+      {savedTemplates.length > 0 && (
+        <div className="w-full max-w-lg">
+          <p className="text-sm font-medium text-gray-700 mb-2">Saved Templates</p>
+          <div className="flex flex-wrap gap-2">
+            {savedTemplates.map((t) => (
+              <div
+                key={t.id}
+                className="flex items-center gap-1 px-3 py-1.5 bg-gray-50 border border-gray-200 rounded-lg text-sm group"
+              >
+                <button
+                  onClick={() => handleLoadTemplate(t.body)}
+                  className="text-gray-700 hover:text-green-600 transition-colors"
+                >
+                  {t.name}
+                </button>
+                <button
+                  onClick={() => handleDeleteTemplate(t.id)}
+                  className="text-gray-300 hover:text-red-500 transition-colors ml-1"
+                >
+                  &times;
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="w-full max-w-lg">
         <div className="flex justify-between items-center mb-2">
           <label className="text-sm font-medium text-gray-700">Template</label>
           <button
-            onClick={insertName}
+            onClick={() => setShowSave(!showSave)}
             className="text-sm text-green-600 hover:text-green-700 font-medium"
           >
-            + Insert {'{name}'}
+            {showSave ? 'Cancel' : 'Save as template'}
           </button>
         </div>
+
+        {showSave && (
+          <div className="flex gap-2 mb-2">
+            <input
+              type="text"
+              value={saveName}
+              onChange={(e) => setSaveName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSaveTemplate()}
+              placeholder="Template name..."
+              className="flex-1 border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-green-500"
+            />
+            <button
+              onClick={handleSaveTemplate}
+              disabled={!saveName.trim() || !template.trim()}
+              className="px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Save
+            </button>
+          </div>
+        )}
+
         <textarea
           ref={textareaRef}
           value={template}
@@ -55,21 +142,28 @@ export function TemplateStep({ contacts, onNext, onBack }: TemplateStepProps) {
           rows={6}
           className="w-full border border-gray-300 rounded-lg p-3 text-gray-800 focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent resize-y"
         />
+
+        {/* Variable insertion buttons */}
+        <div className="flex flex-wrap gap-2 mt-2">
+          {columns.map((col) => (
+            <button
+              key={col}
+              onClick={() => insertVariable(col)}
+              className="px-2.5 py-1 bg-green-50 text-green-700 text-xs rounded-full font-medium hover:bg-green-100 transition-colors border border-green-200"
+            >
+              + {`{${col}}`}
+            </button>
+          ))}
+        </div>
       </div>
 
       {template.trim() && (
         <div className="w-full max-w-lg bg-gray-50 border rounded-lg p-4 text-left">
           <p className="text-sm font-medium text-gray-500 mb-2">
-            Preview (for {contacts[0]?.name ?? 'Recipient'}):
+            Preview (for {firstContact.name || firstContact.number || 'Recipient'}):
           </p>
           <p className="text-gray-800 whitespace-pre-wrap">{preview}</p>
         </div>
-      )}
-
-      {template.trim() && !template.includes('{name}') && (
-        <p className="text-amber-600 text-sm">
-          Tip: Add {'{name}'} to personalize the message for each recipient.
-        </p>
       )}
 
       <div className="flex gap-3">

--- a/client/src/components/UploadStep.tsx
+++ b/client/src/components/UploadStep.tsx
@@ -3,15 +3,17 @@ import { useDropzone } from 'react-dropzone';
 import { uploadFile, type Contact } from '../lib/api';
 
 interface UploadStepProps {
-  onNext: (contacts: Contact[]) => void;
+  onNext: (contacts: Contact[], columns: string[]) => void;
   onBack: () => void;
 }
 
 export function UploadStep({ onNext, onBack }: UploadStepProps) {
   const [contacts, setContacts] = useState<Contact[]>([]);
+  const [columns, setColumns] = useState<string[]>(['name']);
   const [errors, setErrors] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [fileName, setFileName] = useState<string | null>(null);
+  const [newColumnName, setNewColumnName] = useState('');
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: {
@@ -30,6 +32,9 @@ export function UploadStep({ onNext, onBack }: UploadStepProps) {
         const result = await uploadFile(file);
         setContacts(result.contacts);
         setErrors(result.errors);
+        if (result.columns.length > 0) {
+          setColumns(result.columns);
+        }
       } catch (err: unknown) {
         setErrors([err instanceof Error ? err.message : 'Upload failed']);
         setContacts([]);
@@ -39,16 +44,49 @@ export function UploadStep({ onNext, onBack }: UploadStepProps) {
     },
   });
 
+  const addColumn = () => {
+    const name = newColumnName.trim().toLowerCase();
+    if (!name || name === 'number' || columns.includes(name)) return;
+    setColumns([...columns, name]);
+    setContacts(contacts.map((c) => ({ ...c, [name]: '' })));
+    setNewColumnName('');
+  };
+
+  const removeColumn = (col: string) => {
+    setColumns(columns.filter((c) => c !== col));
+    setContacts(contacts.map((c) => {
+      const { [col]: _, ...rest } = c;
+      return rest as Contact;
+    }));
+  };
+
+  const addRow = () => {
+    const newContact: Contact = { number: '' };
+    for (const col of columns) {
+      newContact[col] = '';
+    }
+    setContacts([...contacts, newContact]);
+  };
+
+  const removeRow = (index: number) => {
+    setContacts(contacts.filter((_, i) => i !== index));
+  };
+
+  const updateCell = (index: number, key: string, value: string) => {
+    setContacts(contacts.map((c, i) => i === index ? { ...c, [key]: value } : c));
+  };
+
+  const validContacts = contacts.filter((c) => c.number.trim().length > 0);
+
   return (
     <div className="flex flex-col items-center gap-6">
-      <h2 className="text-2xl font-semibold text-gray-800">Upload Contacts</h2>
       <p className="text-gray-500">
-        Upload a CSV or Excel file with <strong>name</strong> and <strong>number</strong> columns
+        Upload a CSV/Excel file with a <strong>number</strong> column, or add contacts manually below.
       </p>
 
       <div
         {...getRootProps()}
-        className={`w-full max-w-lg border-2 border-dashed rounded-xl p-10 cursor-pointer transition-colors ${
+        className={`w-full max-w-lg border-2 border-dashed rounded-xl p-8 cursor-pointer transition-colors ${
           isDragActive
             ? 'border-green-400 bg-green-50'
             : 'border-gray-300 hover:border-gray-400 bg-white'
@@ -56,7 +94,7 @@ export function UploadStep({ onNext, onBack }: UploadStepProps) {
       >
         <input {...getInputProps()} />
         <div className="text-center">
-          <div className="text-4xl mb-3">📁</div>
+          <div className="text-3xl mb-2">📁</div>
           {loading ? (
             <p className="text-gray-500">Processing file...</p>
           ) : fileName ? (
@@ -71,7 +109,7 @@ export function UploadStep({ onNext, onBack }: UploadStepProps) {
       </div>
 
       {errors.length > 0 && (
-        <div className="w-full max-w-lg bg-amber-50 border border-amber-200 rounded-lg p-4 text-left">
+        <div className="w-full max-w-2xl bg-amber-50 border border-amber-200 rounded-lg p-4 text-left">
           <p className="text-amber-700 font-medium mb-1">Warnings:</p>
           <ul className="text-amber-600 text-sm list-disc list-inside">
             {errors.slice(0, 10).map((e, i) => (
@@ -84,38 +122,118 @@ export function UploadStep({ onNext, onBack }: UploadStepProps) {
         </div>
       )}
 
-      {contacts.length > 0 && (
-        <div className="w-full max-w-lg">
-          <p className="text-green-600 font-medium mb-3">
-            {contacts.length} valid contact{contacts.length !== 1 ? 's' : ''} found
-          </p>
-          <div className="border rounded-lg overflow-hidden">
-            <table className="w-full text-sm text-left">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-4 py-2 text-gray-600">#</th>
-                  <th className="px-4 py-2 text-gray-600">Name</th>
-                  <th className="px-4 py-2 text-gray-600">Number</th>
-                </tr>
-              </thead>
-              <tbody>
-                {contacts.slice(0, 5).map((c, i) => (
-                  <tr key={i} className="border-t">
-                    <td className="px-4 py-2 text-gray-400">{i + 1}</td>
-                    <td className="px-4 py-2">{c.name}</td>
-                    <td className="px-4 py-2 font-mono text-gray-600">{c.number}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            {contacts.length > 5 && (
-              <p className="text-gray-400 text-sm p-3 border-t">
-                ...and {contacts.length - 5} more
-              </p>
-            )}
+      {/* Column manager */}
+      <div className="w-full max-w-2xl">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-sm font-medium text-gray-700">Columns</p>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={newColumnName}
+              onChange={(e) => setNewColumnName(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && addColumn()}
+              placeholder="New column..."
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm w-36 focus:outline-none focus:ring-2 focus:ring-green-500"
+            />
+            <button
+              onClick={addColumn}
+              disabled={!newColumnName.trim() || newColumnName.trim().toLowerCase() === 'number' || columns.includes(newColumnName.trim().toLowerCase())}
+              className="px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              + Add
+            </button>
           </div>
         </div>
-      )}
+        <div className="flex flex-wrap gap-2 mb-4">
+          <span className="px-3 py-1 bg-gray-100 text-gray-500 text-xs rounded-full font-medium">number (required)</span>
+          {columns.map((col) => (
+            <span key={col} className="px-3 py-1 bg-green-50 text-green-700 text-xs rounded-full font-medium flex items-center gap-1.5">
+              {col}
+              <button
+                onClick={() => removeColumn(col)}
+                className="text-green-400 hover:text-red-500 transition-colors"
+              >
+                &times;
+              </button>
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Contact table */}
+      <div className="w-full max-w-2xl">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-sm font-medium text-gray-700">
+            {validContacts.length} valid contact{validContacts.length !== 1 ? 's' : ''}
+            {contacts.length !== validContacts.length && ` (${contacts.length} total)`}
+          </p>
+          <button
+            onClick={addRow}
+            className="px-3 py-1.5 border border-green-300 text-green-600 text-sm rounded-lg font-medium hover:bg-green-50 transition-colors"
+          >
+            + Add Row
+          </button>
+        </div>
+
+        {contacts.length > 0 && (
+          <div className="border rounded-lg overflow-hidden">
+            <div className="max-h-96 overflow-auto">
+              <table className="w-full text-sm text-left">
+                <thead className="bg-gray-50 sticky top-0">
+                  <tr>
+                    <th className="px-3 py-2 text-gray-600 w-10">#</th>
+                    <th className="px-3 py-2 text-gray-600">Number</th>
+                    {columns.map((col) => (
+                      <th key={col} className="px-3 py-2 text-gray-600 capitalize">{col}</th>
+                    ))}
+                    <th className="px-3 py-2 text-gray-600 w-10"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {contacts.map((c, i) => (
+                    <tr key={i} className="border-t">
+                      <td className="px-3 py-1.5 text-gray-400">{i + 1}</td>
+                      <td className="px-3 py-1.5">
+                        <input
+                          type="text"
+                          value={c.number}
+                          onChange={(e) => updateCell(i, 'number', e.target.value)}
+                          className="w-full border border-gray-200 rounded px-2 py-1 text-sm font-mono focus:outline-none focus:ring-1 focus:ring-green-500"
+                          placeholder="628..."
+                        />
+                      </td>
+                      {columns.map((col) => (
+                        <td key={col} className="px-3 py-1.5">
+                          <input
+                            type="text"
+                            value={c[col] || ''}
+                            onChange={(e) => updateCell(i, col, e.target.value)}
+                            className="w-full border border-gray-200 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-green-500"
+                          />
+                        </td>
+                      ))}
+                      <td className="px-3 py-1.5">
+                        <button
+                          onClick={() => removeRow(i)}
+                          className="text-gray-300 hover:text-red-500 transition-colors"
+                        >
+                          &times;
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {contacts.length === 0 && (
+          <div className="border-2 border-dashed border-gray-200 rounded-lg p-8 text-center text-gray-400">
+            No contacts yet. Upload a file or add rows manually.
+          </div>
+        )}
+      </div>
 
       <div className="flex gap-3">
         <button
@@ -125,8 +243,8 @@ export function UploadStep({ onNext, onBack }: UploadStepProps) {
           ← Back
         </button>
         <button
-          onClick={() => onNext(contacts)}
-          disabled={contacts.length === 0}
+          onClick={() => onNext(validContacts, columns)}
+          disabled={validContacts.length === 0}
           className="px-6 py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >
           Next →

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,14 +1,44 @@
 import { getToken } from './auth';
 
 export interface Contact {
-  name: string;
   number: string;
+  [key: string]: string;
 }
 
 export interface UploadResult {
   contacts: Contact[];
+  columns: string[];
   totalRows: number;
   errors: string[];
+}
+
+export interface SavedTemplate {
+  id: number;
+  name: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BlastHistorySummary {
+  id: number;
+  template: string;
+  total: number;
+  sent: number;
+  failed: number;
+  status: string;
+  started_at: string;
+  completed_at: string | null;
+}
+
+export interface BlastRecipientDetail {
+  id: number;
+  number: string;
+  variables: Record<string, string>;
+  rendered_message: string | null;
+  status: string;
+  error: string | null;
+  sent_at: string | null;
 }
 
 function authHeaders(extra?: Record<string, string>): Record<string, string> {
@@ -44,5 +74,46 @@ export async function startBlast(contacts: Contact[], template: string) {
     const err = await res.json();
     throw new Error(err.error || 'Blast failed');
   }
+  return res.json();
+}
+
+// Template CRUD
+export async function getTemplates(): Promise<SavedTemplate[]> {
+  const res = await fetch('/api/template', { headers: authHeaders() });
+  if (!res.ok) throw new Error('Failed to load templates');
+  return res.json();
+}
+
+export async function createTemplate(name: string, body: string): Promise<SavedTemplate> {
+  const res = await fetch('/api/template', {
+    method: 'POST',
+    headers: authHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify({ name, body }),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error || 'Failed to create template');
+  }
+  return res.json();
+}
+
+export async function deleteTemplate(id: number): Promise<void> {
+  const res = await fetch(`/api/template/${id}`, {
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error('Failed to delete template');
+}
+
+// Blast history
+export async function getHistory(): Promise<BlastHistorySummary[]> {
+  const res = await fetch('/api/history', { headers: authHeaders() });
+  if (!res.ok) throw new Error('Failed to load history');
+  return res.json();
+}
+
+export async function getHistoryDetail(id: number): Promise<{ blast: BlastHistorySummary; recipients: BlastRecipientDetail[] }> {
+  const res = await fetch(`/api/history/${id}`, { headers: authHeaders() });
+  if (!res.ok) throw new Error('Failed to load blast details');
   return res.json();
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -22,6 +22,41 @@ db.exec(`
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
   );
+
+  CREATE TABLE IF NOT EXISTS templates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    name TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+  );
+
+  CREATE TABLE IF NOT EXISTS blast_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    template TEXT NOT NULL,
+    total INTEGER NOT NULL DEFAULT 0,
+    sent INTEGER NOT NULL DEFAULT 0,
+    failed INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'running',
+    started_at TEXT DEFAULT (datetime('now')),
+    completed_at TEXT
+  );
+
+  CREATE TABLE IF NOT EXISTS blast_recipients (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    blast_id INTEGER NOT NULL REFERENCES blast_history(id),
+    number TEXT NOT NULL,
+    variables TEXT NOT NULL DEFAULT '{}',
+    rendered_message TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    error TEXT,
+    sent_at TEXT
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_blast_history_user ON blast_history(user_id);
+  CREATE INDEX IF NOT EXISTS idx_blast_recipients_blast ON blast_recipients(blast_id);
 `);
 
 console.log('[DB] SQLite initialized at', DB_PATH);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,6 +20,7 @@ import authRouter from './routes/auth.js';
 import uploadRouter from './routes/upload.js';
 import templateRouter from './routes/template.js';
 import { createBlastRouter } from './routes/blast.js';
+import historyRouter from './routes/history.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -39,6 +40,7 @@ app.use('/api/auth', authRouter);
 app.use('/api/upload', requireAuth, uploadRouter);
 app.use('/api/template', requireAuth, templateRouter);
 app.use('/api/blast', requireAuth, createBlastRouter(io));
+app.use('/api/history', requireAuth, historyRouter);
 
 app.get('/api/status', requireAuth, (_req, res) => {
   res.json({ status: getStatus() });

--- a/server/src/routes/blast.ts
+++ b/server/src/routes/blast.ts
@@ -3,11 +3,14 @@ import type { Server as SocketIOServer } from 'socket.io';
 import { getSocket, getStatus } from '../whatsapp/session.js';
 import { executeBlast } from '../whatsapp/sender.js';
 import type { Contact } from '../types.js';
+import type { AuthRequest } from '../middleware/auth.js';
+import db from '../db.js';
 
 export function createBlastRouter(io: SocketIOServer): Router {
   const router = Router();
 
   router.post('/', (req, res) => {
+    const { user } = req as AuthRequest;
     const { contacts, template } = req.body as {
       contacts: Contact[];
       template: string;
@@ -34,13 +37,32 @@ export function createBlastRouter(io: SocketIOServer): Router {
       return;
     }
 
+    // Create blast history record
+    const historyResult = db.prepare(
+      'INSERT INTO blast_history (user_id, template, total) VALUES (?, ?, ?)'
+    ).run(user!.id, template, contacts.length);
+    const blastId = Number(historyResult.lastInsertRowid);
+
+    // Insert all recipients
+    const insertRecipient = db.prepare(
+      'INSERT INTO blast_recipients (blast_id, number, variables) VALUES (?, ?, ?)'
+    );
+    const insertMany = db.transaction((items: Contact[]) => {
+      for (const c of items) {
+        const { number, ...variables } = c;
+        insertRecipient.run(blastId, number, JSON.stringify(variables));
+      }
+    });
+    insertMany(contacts);
+
     // Start blast asynchronously
-    executeBlast(sock, contacts, template, io).catch((err) => {
+    executeBlast(sock, contacts, template, io, blastId).catch((err) => {
       console.error('Blast execution error:', err);
+      db.prepare("UPDATE blast_history SET status = 'error', completed_at = datetime('now') WHERE id = ?").run(blastId);
       io.emit('blast:error', { number: '', error: 'Blast execution failed' });
     });
 
-    res.json({ status: 'started', totalMessages: contacts.length });
+    res.json({ status: 'started', totalMessages: contacts.length, blastId });
   });
 
   return router;

--- a/server/src/routes/history.ts
+++ b/server/src/routes/history.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import db from '../db.js';
+import type { AuthRequest } from '../middleware/auth.js';
+
+const router = Router();
+
+// List all blast history for the authenticated user
+router.get('/', (req, res) => {
+  const { user } = req as AuthRequest;
+  const history = db.prepare(
+    'SELECT id, template, total, sent, failed, status, started_at, completed_at FROM blast_history WHERE user_id = ? ORDER BY started_at DESC'
+  ).all(user!.id);
+  res.json(history);
+});
+
+// Get blast detail with recipients
+router.get('/:id', (req, res) => {
+  const { user } = req as AuthRequest;
+  const { id } = req.params;
+
+  const blast = db.prepare(
+    'SELECT id, template, total, sent, failed, status, started_at, completed_at FROM blast_history WHERE id = ? AND user_id = ?'
+  ).get(id, user!.id);
+
+  if (!blast) {
+    res.status(404).json({ error: 'Blast not found' });
+    return;
+  }
+
+  const recipients = db.prepare(
+    'SELECT id, number, variables, rendered_message, status, error, sent_at FROM blast_recipients WHERE blast_id = ? ORDER BY id'
+  ).all(id);
+
+  // Parse variables JSON for each recipient
+  const parsed = (recipients as Array<{ variables: string; [key: string]: unknown }>).map((r) => ({
+    ...r,
+    variables: JSON.parse(r.variables as string),
+  }));
+
+  res.json({ blast, recipients: parsed });
+});
+
+export default router;

--- a/server/src/routes/template.ts
+++ b/server/src/routes/template.ts
@@ -1,21 +1,63 @@
 import { Router } from 'express';
+import db from '../db.js';
+import type { AuthRequest } from '../middleware/auth.js';
 
 const router = Router();
 
-let currentTemplate = '';
-
-router.get('/', (_req, res) => {
-  res.json({ template: currentTemplate });
+// List all templates for the authenticated user
+router.get('/', (req, res) => {
+  const { user } = req as AuthRequest;
+  const templates = db.prepare('SELECT id, name, body, created_at, updated_at FROM templates WHERE user_id = ? ORDER BY updated_at DESC').all(user!.id);
+  res.json(templates);
 });
 
+// Create a new template
 router.post('/', (req, res) => {
-  const { template } = req.body;
-  if (typeof template !== 'string') {
-    res.status(400).json({ error: 'Template must be a string' });
+  const { user } = req as AuthRequest;
+  const { name, body } = req.body;
+
+  if (!name || typeof name !== 'string') {
+    res.status(400).json({ error: 'Template name is required' });
     return;
   }
-  currentTemplate = template;
-  res.json({ template: currentTemplate });
+  if (!body || typeof body !== 'string') {
+    res.status(400).json({ error: 'Template body is required' });
+    return;
+  }
+
+  const result = db.prepare('INSERT INTO templates (user_id, name, body) VALUES (?, ?, ?)').run(user!.id, name.trim(), body);
+  const template = db.prepare('SELECT id, name, body, created_at, updated_at FROM templates WHERE id = ?').get(result.lastInsertRowid);
+  res.status(201).json(template);
+});
+
+// Update a template
+router.put('/:id', (req, res) => {
+  const { user } = req as AuthRequest;
+  const { id } = req.params;
+  const { name, body } = req.body;
+
+  const existing = db.prepare('SELECT id FROM templates WHERE id = ? AND user_id = ?').get(id, user!.id);
+  if (!existing) {
+    res.status(404).json({ error: 'Template not found' });
+    return;
+  }
+
+  db.prepare("UPDATE templates SET name = COALESCE(?, name), body = COALESCE(?, body), updated_at = datetime('now') WHERE id = ?").run(name || null, body || null, id);
+  const template = db.prepare('SELECT id, name, body, created_at, updated_at FROM templates WHERE id = ?').get(id);
+  res.json(template);
+});
+
+// Delete a template
+router.delete('/:id', (req, res) => {
+  const { user } = req as AuthRequest;
+  const { id } = req.params;
+
+  const result = db.prepare('DELETE FROM templates WHERE id = ? AND user_id = ?').run(id, user!.id);
+  if (result.changes === 0) {
+    res.status(404).json({ error: 'Template not found' });
+    return;
+  }
+  res.json({ success: true });
 });
 
 export default router;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,10 +1,11 @@
 export interface Contact {
-  name: string;
   number: string;
+  [key: string]: string;
 }
 
 export interface UploadResult {
   contacts: Contact[];
+  columns: string[];
   totalRows: number;
   errors: string[];
 }
@@ -13,6 +14,35 @@ export interface BlastProgress {
   sent: number;
   failed: number;
   total: number;
+}
+
+export interface SavedTemplate {
+  id: number;
+  name: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BlastHistorySummary {
+  id: number;
+  template: string;
+  total: number;
+  sent: number;
+  failed: number;
+  status: string;
+  started_at: string;
+  completed_at: string | null;
+}
+
+export interface BlastRecipientDetail {
+  id: number;
+  number: string;
+  variables: Record<string, string>;
+  rendered_message: string | null;
+  status: string;
+  error: string | null;
+  sent_at: string | null;
 }
 
 export type WAStatus = 'disconnected' | 'qr_pending' | 'connected' | 'error';

--- a/server/src/utils/fileParser.ts
+++ b/server/src/utils/fileParser.ts
@@ -26,19 +26,34 @@ function validateNumber(num: string): boolean {
   return /^\d{10,15}$/.test(num);
 }
 
+function normalizeHeaderKey(header: string): string {
+  const lower = header.trim().toLowerCase();
+  if (NAME_ALIASES.includes(lower)) return 'name';
+  if (NUMBER_ALIASES.includes(lower)) return 'number';
+  return header.trim();
+}
+
 function parseRows(rows: Record<string, string>[], headers: string[]): UploadResult {
-  const nameCol = findColumn(headers, NAME_ALIASES);
   const numberCol = findColumn(headers, NUMBER_ALIASES);
 
-  if (!nameCol || !numberCol) {
-    const missing = [];
-    if (!nameCol) missing.push('name');
-    if (!numberCol) missing.push('number');
+  if (!numberCol) {
     return {
       contacts: [],
+      columns: [],
       totalRows: rows.length,
-      errors: [`Missing required column(s): ${missing.join(', ')}. Found columns: ${headers.join(', ')}`],
+      errors: [`Missing required column: number. Found columns: ${headers.join(', ')}`],
     };
+  }
+
+  // Build column list (all non-number headers, normalized)
+  const columns: string[] = [];
+  const headerMap: { original: string; key: string }[] = [];
+
+  for (const h of headers) {
+    const key = normalizeHeaderKey(h);
+    if (key === 'number') continue;
+    if (!columns.includes(key)) columns.push(key);
+    headerMap.push({ original: h, key });
   }
 
   const contacts: Contact[] = [];
@@ -46,11 +61,10 @@ function parseRows(rows: Record<string, string>[], headers: string[]): UploadRes
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
-    const name = row[nameCol]?.trim();
     const rawNumber = row[numberCol]?.trim();
 
-    if (!name || !rawNumber) {
-      errors.push(`Row ${i + 2}: missing name or number`);
+    if (!rawNumber) {
+      errors.push(`Row ${i + 2}: missing number`);
       continue;
     }
 
@@ -60,10 +74,14 @@ function parseRows(rows: Record<string, string>[], headers: string[]): UploadRes
       continue;
     }
 
-    contacts.push({ name, number });
+    const contact: Contact = { number };
+    for (const { original, key } of headerMap) {
+      contact[key] = row[original]?.trim() || '';
+    }
+    contacts.push(contact);
   }
 
-  return { contacts, totalRows: rows.length, errors };
+  return { contacts, columns, totalRows: rows.length, errors };
 }
 
 export function parseCSV(buffer: Buffer): UploadResult {
@@ -82,7 +100,7 @@ export function parseExcel(buffer: Buffer): UploadResult {
   const data = XLSX.utils.sheet_to_json<Record<string, string>>(sheet, { defval: '' });
 
   if (data.length === 0) {
-    return { contacts: [], totalRows: 0, errors: ['File is empty'] };
+    return { contacts: [], columns: [], totalRows: 0, errors: ['File is empty'] };
   }
 
   const headers = Object.keys(data[0]);
@@ -93,5 +111,5 @@ export function parseFile(buffer: Buffer, filename: string): UploadResult {
   const ext = filename.toLowerCase().split('.').pop();
   if (ext === 'csv') return parseCSV(buffer);
   if (ext === 'xlsx' || ext === 'xls') return parseExcel(buffer);
-  return { contacts: [], totalRows: 0, errors: [`Unsupported file type: .${ext}`] };
+  return { contacts: [], columns: [], totalRows: 0, errors: [`Unsupported file type: .${ext}`] };
 }

--- a/server/src/whatsapp/sender.ts
+++ b/server/src/whatsapp/sender.ts
@@ -3,6 +3,7 @@ import type { Server as SocketIOServer } from 'socket.io';
 import type { Contact } from '../types.js';
 import { BLAST_CONFIG } from '../config.js';
 import { renderTemplate } from '../utils/templateEngine.js';
+import db from '../db.js';
 
 function randomDelay(): number {
   return BLAST_CONFIG.minDelay + Math.random() * (BLAST_CONFIG.maxDelay - BLAST_CONFIG.minDelay);
@@ -16,36 +17,48 @@ export async function executeBlast(
   sock: ReturnType<typeof makeWASocket>,
   contacts: Contact[],
   template: string,
-  io: SocketIOServer
+  io: SocketIOServer,
+  blastId: number
 ): Promise<void> {
   let sent = 0;
   let failed = 0;
   const total = contacts.length;
 
+  const updateRecipient = db.prepare(
+    "UPDATE blast_recipients SET status = ?, error = ?, rendered_message = ?, sent_at = datetime('now') WHERE id = (SELECT id FROM blast_recipients WHERE blast_id = ? AND number = ? AND status = 'pending' LIMIT 1)"
+  );
+  const updateHistory = db.prepare(
+    "UPDATE blast_history SET sent = ?, failed = ?, status = ?, completed_at = datetime('now') WHERE id = ?"
+  );
+
   for (let i = 0; i < contacts.length; i++) {
     const contact = contacts[i];
-    const message = renderTemplate(template, { name: contact.name });
-    const jid = `${contact.number}@s.whatsapp.net`;
+    const { number, ...variables } = contact;
+    const message = renderTemplate(template, variables);
+    const jid = `${number}@s.whatsapp.net`;
 
     try {
       await sock.sendMessage(jid, { text: message });
       sent++;
+      updateRecipient.run('sent', null, message, blastId, number);
     } catch (err: unknown) {
       const errorMsg = err instanceof Error ? err.message : 'Unknown error';
 
-      // Retry once if configured
       if (BLAST_CONFIG.retryOnFail) {
         await sleep(BLAST_CONFIG.retryDelay);
         try {
           await sock.sendMessage(jid, { text: message });
           sent++;
+          updateRecipient.run('sent', null, message, blastId, number);
         } catch {
           failed++;
-          io.emit('blast:error', { number: contact.number, name: contact.name, error: errorMsg });
+          updateRecipient.run('failed', errorMsg, message, blastId, number);
+          io.emit('blast:error', { number, name: variables.name || '', error: errorMsg });
         }
       } else {
         failed++;
-        io.emit('blast:error', { number: contact.number, name: contact.name, error: errorMsg });
+        updateRecipient.run('failed', errorMsg, message, blastId, number);
+        io.emit('blast:error', { number, name: variables.name || '', error: errorMsg });
       }
     }
 
@@ -59,5 +72,6 @@ export async function executeBlast(
     }
   }
 
+  updateHistory.run(sent, failed, 'completed', blastId);
   io.emit('blast:complete', { sent, failed, total });
 }


### PR DESCRIPTION
## Summary

- **Dynamic template variables**: all CSV columns (beyond `number`) automatically become `{variable}` placeholders in templates
- **Manual contact editor**: add/edit/delete contact rows + custom columns from the UI, works alongside CSV upload
- **Saved templates**: named templates stored in SQLite, reusable across blasts (per-user)
- **Blast history**: full history with summary stats + per-recipient detail (status, rendered message, errors)

## Database Changes

- New `templates` table (user_id, name, body)
- New `blast_history` table (user_id, template, total, sent, failed, status)
- New `blast_recipients` table (blast_id, number, variables JSON, rendered_message, status, error)

## UI Changes

- **UploadStep**: dynamic column table + manual contact editor (add/remove columns & rows)
- **TemplateStep**: dynamic "Insert {variable}" buttons + saved template picker/save
- **PreviewStep**: dynamic columns based on contact data
- **HistoryPage**: new page showing past blasts with expandable per-recipient details
- **Sidebar**: added History menu item (accessible without WA connection)

## Test plan

- [x] Upload CSV with columns: number, name, company → all columns appear in editable table
- [x] Add manual contact with custom column → appears alongside CSV contacts
- [x] Template step shows Insert buttons for all available columns
- [x] Save a template → reload → template appears in saved templates list
- [x] Start blast → blast_history record created → recipients tracked per-message
- [x] History page shows past blasts → expand to see per-recipient details

Closes #3