### PR TITLE
fix: FK constraint on stale JWT + contact number erasure

### DIFF
--- a/client/src/components/UploadStep.tsx
+++ b/client/src/components/UploadStep.tsx
@@ -74,7 +74,7 @@ export function UploadStep({ onNext, onBack }: UploadStepProps) {
   };
 
   const updateCell = (index: number, key: string, value: string) => {
-    setContacts(contacts.map((c, i) => i === index ? { ...c, [key]: value } : c));
+    setContacts(prev => prev.map((c, i) => i === index ? { ...c, [key]: value } : c));
   };
 
   const validContacts = contacts.filter((c) => c.number.trim().length > 0);

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -49,6 +49,22 @@ function authHeaders(extra?: Record<string, string>): Record<string, string> {
   };
 }
 
+async function handleError(res: Response, fallback: string): Promise<never> {
+  if (res.status === 401) {
+    const { clearAuth } = await import('./auth');
+    clearAuth();
+    window.location.reload();
+  }
+  let message = fallback;
+  try {
+    const err = await res.json();
+    message = err.error || fallback;
+  } catch {
+    // Response wasn't JSON (e.g. HTML from catch-all)
+  }
+  throw new Error(message);
+}
+
 export async function uploadFile(file: File): Promise<UploadResult> {
   const formData = new FormData();
   formData.append('file', file);
@@ -57,10 +73,7 @@ export async function uploadFile(file: File): Promise<UploadResult> {
     headers: authHeaders(),
     body: formData,
   });
-  if (!res.ok) {
-    const err = await res.json();
-    throw new Error(err.error || 'Upload failed');
-  }
+  if (!res.ok) await handleError(res, 'Upload failed');
   return res.json();
 }
 
@@ -70,17 +83,14 @@ export async function startBlast(contacts: Contact[], template: string) {
     headers: authHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ contacts, template }),
   });
-  if (!res.ok) {
-    const err = await res.json();
-    throw new Error(err.error || 'Blast failed');
-  }
+  if (!res.ok) await handleError(res, 'Blast failed');
   return res.json();
 }
 
 // Template CRUD
 export async function getTemplates(): Promise<SavedTemplate[]> {
   const res = await fetch('/api/template', { headers: authHeaders() });
-  if (!res.ok) throw new Error('Failed to load templates');
+  if (!res.ok) await handleError(res, 'Failed to load templates');
   return res.json();
 }
 
@@ -90,10 +100,7 @@ export async function createTemplate(name: string, body: string): Promise<SavedT
     headers: authHeaders({ 'Content-Type': 'application/json' }),
     body: JSON.stringify({ name, body }),
   });
-  if (!res.ok) {
-    const err = await res.json();
-    throw new Error(err.error || 'Failed to create template');
-  }
+  if (!res.ok) await handleError(res, 'Failed to create template');
   return res.json();
 }
 
@@ -102,7 +109,7 @@ export async function deleteTemplate(id: number): Promise<void> {
     method: 'DELETE',
     headers: authHeaders(),
   });
-  if (!res.ok) throw new Error('Failed to delete template');
+  if (!res.ok) await handleError(res, 'Failed to delete template');
 }
 
 // WA contact search
@@ -124,12 +131,12 @@ export async function searchWAContacts(query: string): Promise<{ results: WACont
 // Blast history
 export async function getHistory(): Promise<BlastHistorySummary[]> {
   const res = await fetch('/api/history', { headers: authHeaders() });
-  if (!res.ok) throw new Error('Failed to load history');
+  if (!res.ok) await handleError(res, 'Failed to load history');
   return res.json();
 }
 
 export async function getHistoryDetail(id: number): Promise<{ blast: BlastHistorySummary; recipients: BlastRecipientDetail[] }> {
   const res = await fetch(`/api/history/${id}`, { headers: authHeaders() });
-  if (!res.ok) throw new Error('Failed to load blast details');
+  if (!res.ok) await handleError(res, 'Failed to load blast details');
   return res.json();
 }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { JWT_SECRET } from '../config.js';
+import db from '../db.js';
 
 export interface AuthRequest extends Request {
   user?: { id: number; username: string };
@@ -15,6 +16,12 @@ export function requireAuth(req: AuthRequest, res: Response, next: NextFunction)
 
   try {
     const payload = jwt.verify(header.slice(7), JWT_SECRET) as { id: number; username: string };
+    // Verify user still exists in DB (handles DB recreation with stale tokens)
+    const exists = db.prepare('SELECT id FROM users WHERE id = ?').get(payload.id);
+    if (!exists) {
+      res.status(401).json({ error: 'User no longer exists. Please log in again.' });
+      return;
+    }
     req.user = payload;
     next();
   } catch {


### PR DESCRIPTION
## Summary
- **Validate user exists in DB** in `requireAuth` middleware — stale JWT tokens from recreated databases now get a proper 401 instead of unhandled FK errors
- **Fix number erasure in contact table** — stale closure in `updateCell` caused typed numbers to disappear when clicking another row; now uses functional `setState`
- **Safe error parsing** — API helpers gracefully handle non-JSON responses (e.g. HTML from catch-all) instead of crashing with "Unexpected token '<'"
- **Auto-logout on 401** — clears auth and reloads page when token is rejected

## Test plan
- [ ] Delete DB, restart server, try to blast with old browser session → should redirect to login
- [ ] Type a number in one row, click another row → number should persist
- [ ] Normal blast flow still works after re-login

Closes #7