### PR TITLE
feat: mobile-friendly responsive UI

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,6 +25,7 @@ function Dashboard() {
   const socket = useSocket();
   const [page, setPage] = useState<Page>('connect');
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [columns, setColumns] = useState<string[]>(['name']);
   const [template, setTemplate] = useState('');
@@ -45,73 +46,91 @@ function Dashboard() {
         collapsed={sidebarCollapsed}
         socket={socket}
         blastActive={blastActive}
+        mobileOpen={mobileMenuOpen}
+        onMobileClose={() => setMobileMenuOpen(false)}
       />
 
-      <main className="flex-1 p-8">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="text-2xl font-bold text-gray-800 mb-6">{PAGE_TITLES[page]}</h2>
+      <main className="flex-1 min-w-0">
+        {/* Mobile top bar */}
+        <div className="md:hidden flex items-center justify-between px-4 py-3 bg-white border-b border-gray-200 sticky top-0 z-30">
+          <button
+            onClick={() => setMobileMenuOpen(true)}
+            className="p-2 -ml-2 rounded-lg text-gray-600 hover:bg-gray-100 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+            </svg>
+          </button>
+          <h1 className="text-sm font-semibold text-gray-800">{PAGE_TITLES[page]}</h1>
+          <div className="w-9" /> {/* spacer for centering */}
+        </div>
 
-          <div className="bg-white rounded-xl shadow-sm border p-8">
-            {page === 'connect' && (
-              <AuthStep socket={socket} onNext={() => setPage('upload')} />
-            )}
-            {page === 'upload' && (
-              <UploadStep
-                initialContacts={contacts}
-                initialColumns={columns}
-                onChange={(c, cols) => { setContacts(c); setColumns(cols); }}
-                onNext={(c, cols) => {
-                  setContacts(c);
-                  setColumns(cols);
-                  setPage('template');
-                }}
-                onBack={() => setPage('connect')}
-              />
-            )}
-            {page === 'template' && (
-              <TemplateStep
-                contacts={contacts}
-                columns={columns}
-                initialTemplate={template}
-                onTemplateChange={setTemplate}
-                onNext={(t) => {
-                  setTemplate(t);
-                  setPage('preview');
-                }}
-                onBack={() => setPage('upload')}
-              />
-            )}
-            {page === 'preview' && (
-              <PreviewStep
-                contacts={contacts}
-                columns={columns}
-                template={template}
-                onConfirm={() => { setBlastActive(true); setPage('send'); }}
-                onBack={() => setPage('template')}
-              />
-            )}
-            {page === 'send' && (
-              <BlastStep
-                socket={socket}
-                contacts={contacts}
-                template={template}
-                onReset={() => {
-                  setBlastActive(false);
-                  setContacts([]);
-                  setColumns(['name']);
-                  setTemplate('');
-                  setPage('upload');
-                }}
-              />
-            )}
-            {page === 'history' && (
-              <HistoryPage />
-            )}
+        <div className="p-4 md:p-8">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="hidden md:block text-2xl font-bold text-gray-800 mb-6">{PAGE_TITLES[page]}</h2>
+
+            <div className="bg-white rounded-xl shadow-sm border p-4 md:p-8">
+              {page === 'connect' && (
+                <AuthStep socket={socket} onNext={() => setPage('upload')} />
+              )}
+              {page === 'upload' && (
+                <UploadStep
+                  initialContacts={contacts}
+                  initialColumns={columns}
+                  onChange={(c, cols) => { setContacts(c); setColumns(cols); }}
+                  onNext={(c, cols) => {
+                    setContacts(c);
+                    setColumns(cols);
+                    setPage('template');
+                  }}
+                  onBack={() => setPage('connect')}
+                />
+              )}
+              {page === 'template' && (
+                <TemplateStep
+                  contacts={contacts}
+                  columns={columns}
+                  initialTemplate={template}
+                  onTemplateChange={setTemplate}
+                  onNext={(t) => {
+                    setTemplate(t);
+                    setPage('preview');
+                  }}
+                  onBack={() => setPage('upload')}
+                />
+              )}
+              {page === 'preview' && (
+                <PreviewStep
+                  contacts={contacts}
+                  columns={columns}
+                  template={template}
+                  onConfirm={() => { setBlastActive(true); setPage('send'); }}
+                  onBack={() => setPage('template')}
+                />
+              )}
+              {page === 'send' && (
+                <BlastStep
+                  socket={socket}
+                  contacts={contacts}
+                  template={template}
+                  onReset={() => {
+                    setBlastActive(false);
+                    setContacts([]);
+                    setColumns(['name']);
+                    setTemplate('');
+                    setPage('upload');
+                  }}
+                />
+              )}
+              {page === 'history' && (
+                <HistoryPage />
+              )}
+            </div>
+
+            <footer className="text-center text-gray-400 text-sm mt-8 pb-4">
+              Created by Raihan Afiandi
+            </footer>
           </div>
-
-          <footer className="text-center text-gray-400 text-sm mt-8 pb-4">
-            Created by Raihan Afiandi
-          </footer>
         </div>
       </main>
     </div>

--- a/client/src/components/AuthStep.tsx
+++ b/client/src/components/AuthStep.tsx
@@ -59,21 +59,21 @@ export function AuthStep({ socket, onNext }: AuthStepProps) {
   };
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <p className="text-gray-500">Scan the QR code with your WhatsApp to get started</p>
+    <div className="flex flex-col items-center gap-4 md:gap-6">
+      <p className="text-gray-500 text-sm md:text-base text-center">Scan the QR code with your WhatsApp to get started</p>
 
-      <div className="w-72 h-72 border border-gray-200 rounded-xl flex items-center justify-center bg-white shadow-sm">
+      <div className="w-64 h-64 md:w-72 md:h-72 border border-gray-200 rounded-xl flex items-center justify-center bg-white shadow-sm">
         {isConnected ? (
-          <div className="text-center">
-            <div className="w-16 h-16 mx-auto mb-3 rounded-full bg-green-100 flex items-center justify-center">
-              <svg className="w-8 h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+          <div className="text-center px-4">
+            <div className="w-14 h-14 md:w-16 md:h-16 mx-auto mb-3 rounded-full bg-green-100 flex items-center justify-center">
+              <svg className="w-7 h-7 md:w-8 md:h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
               </svg>
             </div>
-            <p className="text-green-700 font-semibold text-lg">Connected</p>
+            <p className="text-green-700 font-semibold text-base md:text-lg">Connected</p>
             <p className="text-green-600/70 text-sm mt-1">WhatsApp is ready</p>
-            <div className="mt-4 pt-3 border-t border-gray-100">
-              <p className="text-gray-500 text-sm">
+            <div className="mt-3 md:mt-4 pt-3 border-t border-gray-100">
+              <p className="text-gray-500 text-xs md:text-sm">
                 {contactsSynced > 0
                   ? `${contactsSynced.toLocaleString()} contacts synced`
                   : 'No contacts synced yet'}
@@ -108,10 +108,10 @@ export function AuthStep({ socket, onNext }: AuthStepProps) {
             <p className="text-gray-400 text-xs leading-relaxed">{error || 'Unable to connect to WhatsApp'}</p>
           </div>
         ) : qrUrl ? (
-          <img src={qrUrl} alt="WhatsApp QR Code" className="w-64 h-64 rounded-lg" />
+          <img src={qrUrl} alt="WhatsApp QR Code" className="w-56 h-56 md:w-64 md:h-64 rounded-lg" />
         ) : (
           <div className="text-center">
-            <div className="w-44 h-44 mx-auto mb-4 rounded-lg bg-gray-100 relative overflow-hidden">
+            <div className="w-36 h-36 md:w-44 md:h-44 mx-auto mb-4 rounded-lg bg-gray-100 relative overflow-hidden">
               <div
                 className="absolute inset-0"
                 style={{
@@ -131,7 +131,7 @@ export function AuthStep({ socket, onNext }: AuthStepProps) {
         )}
       </div>
 
-      <div className="flex gap-3">
+      <div className="flex gap-3 flex-wrap justify-center">
         {isError && (
           <button
             onClick={handleRetry}
@@ -145,7 +145,7 @@ export function AuthStep({ socket, onNext }: AuthStepProps) {
             onClick={onNext}
             className="px-6 py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 transition-colors"
           >
-            Next →
+            Next &rarr;
           </button>
         )}
         {isConnected && (

--- a/client/src/components/BlastStep.tsx
+++ b/client/src/components/BlastStep.tsx
@@ -54,9 +54,9 @@ export function BlastStep({ socket, contacts, template, onReset }: BlastStepProp
 
   if (blastError) {
     return (
-      <div className="flex flex-col items-center gap-6">
-        <h2 className="text-2xl font-semibold text-red-600">Blast Failed</h2>
-        <p className="text-gray-600">{blastError}</p>
+      <div className="flex flex-col items-center gap-4 md:gap-6">
+        <h2 className="text-xl md:text-2xl font-semibold text-red-600">Blast Failed</h2>
+        <p className="text-gray-600 text-center">{blastError}</p>
         <button
           onClick={onReset}
           className="px-6 py-2.5 border border-gray-300 text-gray-600 rounded-lg font-medium hover:bg-gray-50 transition-colors"
@@ -68,8 +68,8 @@ export function BlastStep({ socket, contacts, template, onReset }: BlastStepProp
   }
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <h2 className="text-2xl font-semibold text-gray-800">
+    <div className="flex flex-col items-center gap-4 md:gap-6">
+      <h2 className="text-xl md:text-2xl font-semibold text-gray-800">
         {isComplete ? 'Blast Complete' : 'Sending Messages...'}
       </h2>
 
@@ -88,17 +88,17 @@ export function BlastStep({ socket, contacts, template, onReset }: BlastStepProp
       </div>
 
       {/* Stats */}
-      <div className="flex gap-8">
+      <div className="flex gap-6 md:gap-8 flex-wrap justify-center">
         <div className="text-center">
-          <p className="text-3xl font-bold text-green-600">{progress.sent}</p>
+          <p className="text-2xl md:text-3xl font-bold text-green-600">{progress.sent}</p>
           <p className="text-sm text-gray-500">Sent</p>
         </div>
         <div className="text-center">
-          <p className="text-3xl font-bold text-red-500">{progress.failed}</p>
+          <p className="text-2xl md:text-3xl font-bold text-red-500">{progress.failed}</p>
           <p className="text-sm text-gray-500">Failed</p>
         </div>
         <div className="text-center">
-          <p className="text-3xl font-bold text-gray-600">{progress.total}</p>
+          <p className="text-2xl md:text-3xl font-bold text-gray-600">{progress.total}</p>
           <p className="text-sm text-gray-500">Total</p>
         </div>
       </div>
@@ -109,7 +109,7 @@ export function BlastStep({ socket, contacts, template, onReset }: BlastStepProp
           <p className="text-red-700 font-medium mb-2">Failed Messages:</p>
           <ul className="text-sm text-red-600 space-y-1">
             {errors.map((e, i) => (
-              <li key={i}>
+              <li key={i} className="break-words">
                 {e.name} ({e.number}): {e.error}
               </li>
             ))}

--- a/client/src/components/HistoryPage.tsx
+++ b/client/src/components/HistoryPage.tsx
@@ -76,10 +76,10 @@ export function HistoryPage() {
         <div key={blast.id} className="border rounded-lg overflow-hidden">
           <button
             onClick={() => viewDetail(blast)}
-            className="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left"
+            className="w-full flex flex-col sm:flex-row sm:items-center justify-between p-3 md:p-4 hover:bg-gray-50 transition-colors text-left gap-2"
           >
             <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-3 mb-1">
+              <div className="flex items-center gap-2 sm:gap-3 mb-1 flex-wrap">
                 <span className={`px-2 py-0.5 text-xs font-medium rounded-full ${statusBadge(blast.status)}`}>
                   {blast.status}
                 </span>
@@ -87,11 +87,11 @@ export function HistoryPage() {
                   {new Date(blast.started_at).toLocaleString()}
                 </span>
               </div>
-              <p className="text-sm text-gray-700 truncate max-w-md">
+              <p className="text-sm text-gray-700 truncate">
                 {blast.template.slice(0, 80)}{blast.template.length > 80 ? '...' : ''}
               </p>
             </div>
-            <div className="flex items-center gap-4 ml-4 shrink-0">
+            <div className="flex items-center gap-3 sm:gap-4 sm:ml-4 shrink-0">
               <div className="text-center">
                 <p className="text-sm font-semibold text-green-600">{blast.sent}</p>
                 <p className="text-xs text-gray-400">Sent</p>
@@ -114,20 +114,20 @@ export function HistoryPage() {
           </button>
 
           {selectedBlast?.id === blast.id && (
-            <div className="border-t bg-gray-50 p-4">
+            <div className="border-t bg-gray-50 p-3 md:p-4">
               {detailLoading ? (
                 <p className="text-gray-400 text-sm text-center py-4">Loading details...</p>
               ) : recipients.length === 0 ? (
                 <p className="text-gray-400 text-sm text-center py-4">No recipient data available.</p>
               ) : (
-                <div className="max-h-64 overflow-auto">
+                <div className="max-h-64 overflow-auto -mx-3 md:mx-0">
                   <table className="w-full text-sm text-left">
                     <thead className="bg-white sticky top-0">
                       <tr>
                         <th className="px-3 py-2 text-gray-500 text-xs">Number</th>
-                        <th className="px-3 py-2 text-gray-500 text-xs">Name</th>
+                        <th className="px-3 py-2 text-gray-500 text-xs hidden sm:table-cell">Name</th>
                         <th className="px-3 py-2 text-gray-500 text-xs">Status</th>
-                        <th className="px-3 py-2 text-gray-500 text-xs">Message</th>
+                        <th className="px-3 py-2 text-gray-500 text-xs hidden md:table-cell">Message</th>
                         <th className="px-3 py-2 text-gray-500 text-xs">Error</th>
                       </tr>
                     </thead>
@@ -135,14 +135,14 @@ export function HistoryPage() {
                       {recipients.map((r) => (
                         <tr key={r.id} className="border-t border-gray-100">
                           <td className="px-3 py-1.5 font-mono text-xs">{r.number}</td>
-                          <td className="px-3 py-1.5">{r.variables.name || '-'}</td>
+                          <td className="px-3 py-1.5 hidden sm:table-cell">{r.variables.name || '-'}</td>
                           <td className={`px-3 py-1.5 font-medium text-xs ${recipientBadge(r.status)}`}>
                             {r.status}
                           </td>
-                          <td className="px-3 py-1.5 text-gray-600 max-w-xs truncate">
+                          <td className="px-3 py-1.5 text-gray-600 max-w-xs truncate hidden md:table-cell">
                             {r.rendered_message || '-'}
                           </td>
-                          <td className="px-3 py-1.5 text-red-500 text-xs max-w-xs truncate">
+                          <td className="px-3 py-1.5 text-red-500 text-xs max-w-[150px] md:max-w-xs truncate">
                             {r.error || '-'}
                           </td>
                         </tr>

--- a/client/src/components/PreviewStep.tsx
+++ b/client/src/components/PreviewStep.tsx
@@ -20,21 +20,21 @@ export function PreviewStep({ contacts, columns, template, onConfirm, onBack }: 
   const estimatedMinutes = Math.ceil(estimatedSeconds / 60);
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <p className="text-gray-500">
+    <div className="flex flex-col items-center gap-4 md:gap-6">
+      <p className="text-gray-500 text-sm md:text-base text-center">
         Review your messages before sending. {contacts.length} message{contacts.length !== 1 ? 's' : ''} will be sent.
         Estimated time: ~{estimatedMinutes} minute{estimatedMinutes !== 1 ? 's' : ''}.
       </p>
 
-      <div className="w-full max-w-3xl border rounded-lg overflow-hidden">
-        <div className="max-h-80 overflow-y-auto">
+      <div className="w-full max-w-3xl border rounded-lg overflow-hidden -mx-4 sm:mx-0">
+        <div className="max-h-80 overflow-auto">
           <table className="w-full text-sm text-left">
             <thead className="bg-gray-50 sticky top-0">
               <tr>
                 <th className="px-3 py-2 text-gray-600">#</th>
                 <th className="px-3 py-2 text-gray-600">Number</th>
                 {columns.map((col) => (
-                  <th key={col} className="px-3 py-2 text-gray-600 capitalize">{col}</th>
+                  <th key={col} className="px-3 py-2 text-gray-600 capitalize hidden sm:table-cell">{col}</th>
                 ))}
                 <th className="px-3 py-2 text-gray-600">Message Preview</th>
               </tr>
@@ -47,9 +47,9 @@ export function PreviewStep({ contacts, columns, template, onConfirm, onBack }: 
                     <td className="px-3 py-2 text-gray-400">{i + 1}</td>
                     <td className="px-3 py-2 font-mono text-gray-600 text-xs">{number}</td>
                     {columns.map((col) => (
-                      <td key={col} className="px-3 py-2">{c[col] || ''}</td>
+                      <td key={col} className="px-3 py-2 hidden sm:table-cell">{c[col] || ''}</td>
                     ))}
-                    <td className="px-3 py-2 text-gray-700 max-w-xs truncate">
+                    <td className="px-3 py-2 text-gray-700 max-w-[200px] md:max-w-xs truncate">
                       {renderMessage(template, variables)}
                     </td>
                   </tr>
@@ -60,24 +60,24 @@ export function PreviewStep({ contacts, columns, template, onConfirm, onBack }: 
         </div>
       </div>
 
-      <div className="flex gap-3">
+      <div className="flex gap-3 w-full sm:w-auto">
         <button
           onClick={onBack}
-          className="px-6 py-2.5 border border-gray-300 text-gray-600 rounded-lg font-medium hover:bg-gray-50 transition-colors"
+          className="flex-1 sm:flex-initial px-6 py-2.5 border border-gray-300 text-gray-600 rounded-lg font-medium hover:bg-gray-50 transition-colors"
         >
-          ← Back
+          &larr; Back
         </button>
         <button
           onClick={() => setShowModal(true)}
-          className="px-6 py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 transition-colors"
+          className="flex-1 sm:flex-initial px-6 py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 transition-colors"
         >
           Start Blast
         </button>
       </div>
 
       {showModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl p-6 max-w-md mx-4 shadow-xl">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl p-6 max-w-md w-full shadow-xl">
             <h3 className="text-lg font-semibold text-gray-800 mb-2">Confirm Blast</h3>
             <p className="text-gray-600 mb-4">
               You are about to send <strong>{contacts.length}</strong> message{contacts.length !== 1 ? 's' : ''}.

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -20,9 +20,11 @@ interface SidebarProps {
   collapsed: boolean;
   socket: Socket;
   blastActive?: boolean;
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 }
 
-export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collapsed, socket, blastActive }: SidebarProps) {
+export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collapsed, socket, blastActive, mobileOpen, onMobileClose }: SidebarProps) {
   const [waStatus, setWaStatus] = useState<string>('disconnected');
   const [blastOpen, setBlastOpen] = useState(true);
   const [contactsSynced, setContactsSynced] = useState(0);
@@ -58,9 +60,15 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
     waStatus === 'error' ? 'Error' :
     'Disconnected';
 
+  const handleNavigate = (page: Page) => {
+    onNavigate(page);
+    onMobileClose?.();
+  };
+
+  // Collapsed sidebar (desktop only — hidden on mobile)
   if (collapsed) {
     return (
-      <aside className="w-16 bg-white border-r border-gray-200 flex flex-col min-h-screen items-center py-4">
+      <aside className="hidden md:flex w-16 bg-white border-r border-gray-200 flex-col min-h-screen items-center py-4">
         <button
           onClick={onCollapse}
           className="p-2 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors mb-4"
@@ -73,7 +81,7 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
 
         <div className="flex-1 flex flex-col items-center gap-2">
           <button
-            onClick={() => onNavigate('connect')}
+            onClick={() => handleNavigate('connect')}
             className={`p-2 rounded-lg transition-colors ${currentPage === 'connect' ? 'bg-green-50 text-green-700' : 'text-gray-400 hover:bg-gray-100 hover:text-gray-600'}`}
             title="Connect"
           >
@@ -86,7 +94,7 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
             return (
               <button
                 key={p.id}
-                onClick={() => !disabled && onNavigate(p.id as Page)}
+                onClick={() => !disabled && handleNavigate(p.id as Page)}
                 disabled={disabled}
                 className={`p-2 rounded-lg transition-colors ${
                   isActive ? 'bg-green-50 text-green-700' :
@@ -116,8 +124,8 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
     );
   }
 
-  return (
-    <aside className="w-64 bg-white border-r border-gray-200 flex flex-col min-h-screen">
+  const sidebarContent = (
+    <>
       {/* Header */}
       <div className="p-6 border-b border-gray-100 flex items-center justify-between">
         <div>
@@ -125,12 +133,25 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
           <p className="text-xs text-gray-400 mt-1">Message blaster</p>
         </div>
         <button
-          onClick={onCollapse}
-          className="p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+          onClick={() => {
+            onMobileClose?.();
+            onCollapse();
+          }}
+          className="hidden md:block p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
           title="Collapse sidebar"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+          </svg>
+        </button>
+        {/* Mobile close button */}
+        <button
+          onClick={onMobileClose}
+          className="md:hidden p-1.5 rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600 transition-colors"
+          title="Close menu"
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
       </div>
@@ -142,7 +163,7 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
           : 'bg-gray-50 border-gray-100'
       }`}>
         <button
-          onClick={() => onNavigate('connect')}
+          onClick={() => handleNavigate('connect')}
           className={`w-full px-4 py-3 text-left transition-colors rounded-lg ${
             currentPage !== 'connect' ? 'hover:bg-gray-100' : ''
           }`}
@@ -202,7 +223,7 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
               return (
                 <li key={p.id}>
                   <button
-                    onClick={() => !disabled && onNavigate(p.id as Page)}
+                    onClick={() => !disabled && handleNavigate(p.id as Page)}
                     disabled={disabled}
                     className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
                       isActive
@@ -228,7 +249,7 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
       <div className="px-3 mb-2">
         <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider px-3 mb-2">Settings</p>
         <button
-          onClick={() => onNavigate('connect')}
+          onClick={() => handleNavigate('connect')}
           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition-colors ${
             currentPage === 'connect' ? 'bg-green-50 text-green-800' : 'text-gray-600 hover:bg-gray-100'
           }`}
@@ -259,6 +280,32 @@ export function Sidebar({ currentPage, onNavigate, onLogout, onCollapse, collaps
           </svg>
         </button>
       </div>
-    </aside>
+    </>
+  );
+
+  return (
+    <>
+      {/* Mobile backdrop */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 bg-black/40 z-40 md:hidden"
+          onClick={onMobileClose}
+        />
+      )}
+
+      {/* Desktop sidebar — always visible */}
+      <aside className="hidden md:flex w-64 bg-white border-r border-gray-200 flex-col min-h-screen">
+        {sidebarContent}
+      </aside>
+
+      {/* Mobile sidebar — slide-in drawer */}
+      <aside
+        className={`fixed inset-y-0 left-0 z-50 w-72 bg-white border-r border-gray-200 flex flex-col transform transition-transform duration-200 ease-in-out md:hidden ${
+          mobileOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        {sidebarContent}
+      </aside>
+    </>
   );
 }

--- a/client/src/components/TemplateStep.tsx
+++ b/client/src/components/TemplateStep.tsx
@@ -79,8 +79,8 @@ export function TemplateStep({ contacts, columns, onNext, onBack, initialTemplat
   const isValid = template.trim().length > 0;
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <p className="text-gray-500">
+    <div className="flex flex-col items-center gap-4 md:gap-6">
+      <p className="text-gray-500 text-sm md:text-base text-center">
         Write your message. Use variable tags to personalize for each recipient.
       </p>
 
@@ -136,7 +136,7 @@ export function TemplateStep({ contacts, columns, onNext, onBack, initialTemplat
             <button
               onClick={handleSaveTemplate}
               disabled={!saveName.trim() || !template.trim()}
-              className="px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              className="px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shrink-0"
             >
               Save
             </button>
@@ -167,27 +167,27 @@ export function TemplateStep({ contacts, columns, onNext, onBack, initialTemplat
       </div>
 
       {template.trim() && (
-        <div className="w-full max-w-lg bg-gray-50 border rounded-lg p-4 text-left">
+        <div className="w-full max-w-lg bg-gray-50 border rounded-lg p-3 md:p-4 text-left">
           <p className="text-sm font-medium text-gray-500 mb-2">
             Preview (for {firstContact.name || firstContact.number || 'Recipient'}):
           </p>
-          <p className="text-gray-800 whitespace-pre-wrap">{preview}</p>
+          <p className="text-gray-800 whitespace-pre-wrap text-sm md:text-base">{preview}</p>
         </div>
       )}
 
-      <div className="flex gap-3">
+      <div className="flex gap-3 w-full sm:w-auto">
         <button
           onClick={onBack}
-          className="px-6 py-2.5 border border-gray-300 text-gray-600 rounded-lg font-medium hover:bg-gray-50 transition-colors"
+          className="flex-1 sm:flex-initial px-6 py-2.5 border border-gray-300 text-gray-600 rounded-lg font-medium hover:bg-gray-50 transition-colors"
         >
-          ← Back
+          &larr; Back
         </button>
         <button
           onClick={() => onNext(template)}
           disabled={!isValid}
-          className="px-6 py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          className="flex-1 sm:flex-initial px-6 py-2.5 bg-green-600 text-white rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
         >
-          Next →
+          Next &rarr;
         </button>
       </div>
     </div>

--- a/client/src/components/UploadStep.tsx
+++ b/client/src/components/UploadStep.tsx
@@ -90,14 +90,14 @@ export function UploadStep({ onNext, onBack, initialContacts, initialColumns, on
   const validContacts = contacts.filter((c) => c.number.trim().length > 0);
 
   return (
-    <div className="flex flex-col items-center gap-6">
-      <p className="text-gray-500">
+    <div className="flex flex-col items-center gap-4 md:gap-6">
+      <p className="text-gray-500 text-sm md:text-base text-center">
         Upload a CSV/Excel file with contacts, or add them manually. The number column is optional — you can search WhatsApp contacts to fill in numbers.
       </p>
 
       <div
         {...getRootProps()}
-        className={`w-full max-w-lg border-2 border-dashed rounded-xl p-8 cursor-pointer transition-colors ${
+        className={`w-full max-w-lg border-2 border-dashed rounded-xl p-4 md:p-8 cursor-pointer transition-colors ${
           isDragActive
             ? 'border-green-400 bg-green-50'
             : 'border-gray-300 hover:border-gray-400 bg-white'
@@ -135,7 +135,7 @@ export function UploadStep({ onNext, onBack, initialContacts, initialColumns, on
 
       {/* Column manager */}
       <div className="w-full max-w-2xl">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
           <p className="text-sm font-medium text-gray-700">Columns</p>
           <div className="flex items-center gap-2">
             <input
@@ -144,12 +144,12 @@ export function UploadStep({ onNext, onBack, initialContacts, initialColumns, on
               onChange={(e) => setNewColumnName(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && addColumn()}
               placeholder="New column..."
-              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm w-36 focus:outline-none focus:ring-2 focus:ring-green-500"
+              className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm w-full sm:w-36 focus:outline-none focus:ring-2 focus:ring-green-500"
             />
             <button
               onClick={addColumn}
               disabled={!newColumnName.trim() || newColumnName.trim().toLowerCase() === 'number' || columns.includes(newColumnName.trim().toLowerCase())}
-              className="px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              className="px-3 py-1.5 bg-green-600 text-white text-sm rounded-lg font-medium hover:bg-green-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors shrink-0"
             >
               + Add
             </button>
@@ -173,7 +173,7 @@ export function UploadStep({ onNext, onBack, initialContacts, initialColumns, on
 
       {/* Contact table */}
       <div className="w-full max-w-2xl">
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
           <p className="text-sm font-medium text-gray-700">
             {validContacts.length} valid contact{validContacts.length !== 1 ? 's' : ''}
             {contacts.length !== validContacts.length && ` (${contacts.length} total)`}
@@ -214,7 +214,7 @@ export function UploadStep({ onNext, onBack, initialContacts, initialColumns, on
         </div>
 
         {contacts.length > 0 && (
-          <div className="border rounded-lg overflow-hidden">
+          <div className="border rounded-lg overflow-hidden -mx-4 sm:mx-0">
             <div className="max-h-96 overflow-auto">
               <table className="w-full text-sm text-left">
                 <thead className="bg-gray-50 sticky top-0">
@@ -271,12 +271,12 @@ export function UploadStep({ onNext, onBack, initialContacts, initialColumns, on
       </div>
 
       {contacts.length > 0 && validContacts.length < contacts.length && (
-        <div className="w-full max-w-2xl bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 text-sm text-amber-700">
+        <div className="w-full max-w-2xl bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 text-xs md:text-sm text-amber-700">
           {contacts.length - validContacts.length} contact{contacts.length - validContacts.length !== 1 ? 's are' : ' is'} missing a number. Click the number cell to search WhatsApp contacts or type a number directly.
         </div>
       )}
 
-      <div className="flex gap-3">
+      <div className="flex gap-3 w-full sm:w-auto">
         <button
           onClick={onBack}
           className="px-6 py-2.5 border border-gray-300 text-gray-600 rounded-lg font-medium hover:bg-gray-50 transition-colors"


### PR DESCRIPTION
## Summary

- Sidebar becomes a slide-in drawer with backdrop overlay on mobile (`md:` breakpoint)
- Sticky top bar with hamburger menu replaces sidebar on small screens
- Reduced padding (`p-4` vs `p-8`), responsive typography, and full-width nav buttons on mobile
- Tables scroll horizontally and hide less-important columns on small screens
- Stats and card layouts wrap properly on narrow viewports
- QR code box scales down for mobile

## Affected Components

- `Sidebar.tsx` — drawer overlay + mobile close button
- `App.tsx` — mobile top bar, responsive padding, `mobileOpen` state
- `UploadStep.tsx` — responsive column manager + table
- `PreviewStep.tsx` — scrollable table, hidden columns on mobile
- `BlastStep.tsx` — flex-wrap stats, responsive font sizes
- `HistoryPage.tsx` — stacked cards, hidden detail columns on mobile
- `AuthStep.tsx` — scaled QR box and typography
- `TemplateStep.tsx` — responsive form and buttons

## Test plan

- [x] Open on mobile viewport (< 768px) — sidebar should be hidden, hamburger visible
- [x] Tap hamburger — sidebar slides in from left with dark backdrop
- [x] Tap backdrop or X — sidebar closes
- [x] All tables scroll horizontally without breaking layout
- [x] Stats in BlastStep and HistoryPage wrap on narrow screens
- [x] Navigation buttons are full-width on mobile
- [x] Desktop layout remains unchanged (sidebar always visible)

Closes #11