### PR TITLE
fix: isolate WhatsApp sessions per user

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -10,6 +10,13 @@ const db: InstanceType<typeof Database> = new Database(DB_PATH);
 db.pragma('journal_mode = WAL');
 db.pragma('foreign_keys = ON');
 
+// Migration: drop old wa_auth / wa_contacts tables that lack user_id column
+const waAuthSchema = db.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='wa_auth'").get() as { sql: string } | undefined;
+if (waAuthSchema && !waAuthSchema.sql.includes('user_id')) {
+  db.exec('DROP TABLE IF EXISTS wa_contacts; DROP TABLE IF EXISTS wa_auth;');
+  console.log('[DB] Migrated: dropped old wa_auth/wa_contacts tables (no user_id). They will be recreated with per-user isolation.');
+}
+
 db.exec(`
   CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -19,8 +26,10 @@ db.exec(`
   );
 
   CREATE TABLE IF NOT EXISTS wa_auth (
-    key TEXT PRIMARY KEY,
-    value TEXT NOT NULL
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (user_id, key)
   );
 
   CREATE TABLE IF NOT EXISTS templates (
@@ -59,13 +68,15 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS idx_blast_recipients_blast ON blast_recipients(blast_id);
 
   CREATE TABLE IF NOT EXISTS wa_contacts (
-    jid TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    jid TEXT NOT NULL,
     number TEXT NOT NULL,
     name TEXT NOT NULL DEFAULT '',
-    synced INTEGER NOT NULL DEFAULT 0
+    synced INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, jid)
   );
 
-  CREATE INDEX IF NOT EXISTS idx_wa_contacts_synced ON wa_contacts(synced);
+  CREATE INDEX IF NOT EXISTS idx_wa_contacts_user_synced ON wa_contacts(user_id, synced);
 `);
 
 console.log('[DB] SQLite initialized at', DB_PATH);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'url';
 import { SERVER_PORT } from './config.js';
 import './db.js';
 import { initSession, disconnect, getStatus, syncContacts } from './whatsapp/session.js';
-import { setIO, flushBufferToStore, getContactCount, getBufferCount } from './whatsapp/contactStore.js';
+import { flushBufferToStore, getContactCount, getBufferCount } from './whatsapp/contactStore.js';
 
 // Prevent Baileys background tasks from crashing the process
 process.on('uncaughtException', (err) => {
@@ -17,6 +17,7 @@ process.on('unhandledRejection', (err) => {
   console.error('[Process] Unhandled rejection:', err);
 });
 import { requireAuth, verifySocketToken } from './middleware/auth.js';
+import type { AuthRequest } from './middleware/auth.js';
 import authRouter from './routes/auth.js';
 import uploadRouter from './routes/upload.js';
 import templateRouter from './routes/template.js';
@@ -32,8 +33,6 @@ const io = new Server(httpServer, {
   cors: { origin: '*' },
 });
 
-setIO(io);
-
 app.use(cors());
 app.use(express.json());
 
@@ -47,8 +46,9 @@ app.use('/api/blast', requireAuth, createBlastRouter(io));
 app.use('/api/history', requireAuth, historyRouter);
 app.use('/api/wa-contacts', requireAuth, waContactsRouter);
 
-app.get('/api/status', requireAuth, (_req, res) => {
-  res.json({ status: getStatus() });
+app.get('/api/status', requireAuth, (req, res) => {
+  const { user } = req as AuthRequest;
+  res.json({ status: getStatus(user!.id) });
 });
 
 // Serve client static files in production
@@ -75,26 +75,32 @@ io.use((socket, next) => {
 });
 
 io.on('connection', (socket) => {
-  console.log('Client connected:', socket.id);
-  socket.emit('status', getStatus());
-  socket.emit('contacts:count', { synced: getContactCount(), buffered: getBufferCount() });
+  const user = (socket as unknown as { user: { id: number; username: string } }).user;
+  const userId = user.id;
+
+  // Join user-specific room for scoped event delivery
+  socket.join(`user:${userId}`);
+
+  console.log('Client connected:', socket.id, `(user:${userId})`);
+  socket.emit('status', getStatus(userId));
+  socket.emit('contacts:count', { synced: getContactCount(userId), buffered: getBufferCount(userId) });
 
   socket.on('get-contacts-count', () => {
-    socket.emit('contacts:count', { synced: getContactCount(), buffered: getBufferCount() });
+    socket.emit('contacts:count', { synced: getContactCount(userId), buffered: getBufferCount(userId) });
   });
 
   socket.on('sync-contacts', async () => {
     try {
-      await syncContacts();
+      await syncContacts(userId);
     } catch {
       // App state may already be synced
     }
-    flushBufferToStore();
+    flushBufferToStore(userId, io);
   });
 
   socket.on('connect-wa', async () => {
     try {
-      await initSession(io);
+      await initSession(userId, io);
     } catch (err) {
       console.error('Failed to init WhatsApp session:', err);
       socket.emit('status', 'disconnected');
@@ -103,7 +109,7 @@ io.on('connection', (socket) => {
 
   socket.on('disconnect-wa', async () => {
     try {
-      await disconnect(io);
+      await disconnect(userId, io);
     } catch (err) {
       console.error('Failed to logout:', err);
     }

--- a/server/src/routes/blast.ts
+++ b/server/src/routes/blast.ts
@@ -11,17 +11,18 @@ export function createBlastRouter(io: SocketIOServer): Router {
 
   router.post('/', (req, res) => {
     const { user } = req as AuthRequest;
+    const userId = user!.id;
     const { contacts, template } = req.body as {
       contacts: Contact[];
       template: string;
     };
 
-    if (getStatus() !== 'connected') {
+    if (getStatus(userId) !== 'connected') {
       res.status(400).json({ error: 'WhatsApp is not connected' });
       return;
     }
 
-    const sock = getSocket();
+    const sock = getSocket(userId);
     if (!sock) {
       res.status(500).json({ error: 'WhatsApp socket not available' });
       return;
@@ -40,7 +41,7 @@ export function createBlastRouter(io: SocketIOServer): Router {
     // Create blast history record
     const historyResult = db.prepare(
       'INSERT INTO blast_history (user_id, template, total) VALUES (?, ?, ?)'
-    ).run(user!.id, template, contacts.length);
+    ).run(userId, template, contacts.length);
     const blastId = Number(historyResult.lastInsertRowid);
 
     // Insert all recipients
@@ -56,10 +57,10 @@ export function createBlastRouter(io: SocketIOServer): Router {
     insertMany(contacts);
 
     // Start blast asynchronously
-    executeBlast(sock, contacts, template, io, blastId).catch((err) => {
+    executeBlast(sock, contacts, template, io, blastId, userId).catch((err) => {
       console.error('Blast execution error:', err);
       db.prepare("UPDATE blast_history SET status = 'error', completed_at = datetime('now') WHERE id = ?").run(blastId);
-      io.emit('blast:error', { number: '', error: 'Blast execution failed' });
+      io.to(`user:${userId}`).emit('blast:error', { number: '', error: 'Blast execution failed' });
     });
 
     res.json({ status: 'started', totalMessages: contacts.length, blastId });

--- a/server/src/routes/waContacts.ts
+++ b/server/src/routes/waContacts.ts
@@ -1,12 +1,15 @@
 import { Router } from 'express';
 import { searchContacts, getContactCount } from '../whatsapp/contactStore.js';
+import type { AuthRequest } from '../middleware/auth.js';
 
 const router = Router();
 
 router.get('/', (req, res) => {
+  const { user } = req as AuthRequest;
+  const userId = user!.id;
   const q = typeof req.query.q === 'string' ? req.query.q : '';
-  const total = getContactCount();
-  const results = searchContacts(q, 20);
+  const total = getContactCount(userId);
+  const results = searchContacts(userId, q, 20);
   res.json({ results, totalSynced: total });
 });
 

--- a/server/src/whatsapp/authState.ts
+++ b/server/src/whatsapp/authState.ts
@@ -2,28 +2,28 @@ import { WAProto, initAuthCreds, BufferJSON } from '@whiskeysockets/baileys';
 import type { AuthenticationCreds, AuthenticationState, SignalDataTypeMap } from '@whiskeysockets/baileys';
 import db from '../db.js';
 
-const getStmt = db.prepare('SELECT value FROM wa_auth WHERE key = ?');
-const setStmt = db.prepare('INSERT OR REPLACE INTO wa_auth (key, value) VALUES (?, ?)');
-const delStmt = db.prepare('DELETE FROM wa_auth WHERE key = ?');
-const delPrefixStmt = db.prepare('DELETE FROM wa_auth WHERE key LIKE ?');
+const getStmt = db.prepare('SELECT value FROM wa_auth WHERE user_id = ? AND key = ?');
+const setStmt = db.prepare('INSERT OR REPLACE INTO wa_auth (user_id, key, value) VALUES (?, ?, ?)');
+const delStmt = db.prepare('DELETE FROM wa_auth WHERE user_id = ? AND key = ?');
+const delAllStmt = db.prepare('DELETE FROM wa_auth WHERE user_id = ?');
 
-function readData(key: string): unknown | null {
-  const row = getStmt.get(key) as { value: string } | undefined;
+function readData(userId: number, key: string): unknown | null {
+  const row = getStmt.get(userId, key) as { value: string } | undefined;
   if (!row) return null;
   return JSON.parse(row.value, BufferJSON.reviver);
 }
 
-function writeData(key: string, data: unknown): void {
+function writeData(userId: number, key: string, data: unknown): void {
   const value = JSON.stringify(data, BufferJSON.replacer);
-  setStmt.run(key, value);
+  setStmt.run(userId, key, value);
 }
 
-function removeData(key: string): void {
-  delStmt.run(key);
+function removeData(userId: number, key: string): void {
+  delStmt.run(userId, key);
 }
 
-export function useSQLiteAuthState(): { state: AuthenticationState; saveCreds: () => void } {
-  const creds: AuthenticationCreds = (readData('creds') as AuthenticationCreds) || initAuthCreds();
+export function useSQLiteAuthState(userId: number): { state: AuthenticationState; saveCreds: () => void } {
+  const creds: AuthenticationCreds = (readData(userId, 'creds') as AuthenticationCreds) || initAuthCreds();
 
   const state: AuthenticationState = {
     creds,
@@ -31,7 +31,7 @@ export function useSQLiteAuthState(): { state: AuthenticationState; saveCreds: (
       get: <T extends keyof SignalDataTypeMap>(type: T, ids: string[]) => {
         const data: { [id: string]: SignalDataTypeMap[T] } = {};
         for (const id of ids) {
-          const value = readData(`${type}-${id}`);
+          const value = readData(userId, `${type}-${id}`);
           if (value) {
             if (type === 'app-state-sync-key') {
               data[id] = WAProto.Message.AppStateSyncKeyData.fromObject(value) as unknown as SignalDataTypeMap[T];
@@ -49,9 +49,9 @@ export function useSQLiteAuthState(): { state: AuthenticationState; saveCreds: (
               const value = data[category as keyof SignalDataTypeMap]![id];
               const key = `${category}-${id}`;
               if (value) {
-                writeData(key, value);
+                writeData(userId, key, value);
               } else {
-                removeData(key);
+                removeData(userId, key);
               }
             }
           }
@@ -62,13 +62,13 @@ export function useSQLiteAuthState(): { state: AuthenticationState; saveCreds: (
   };
 
   const saveCreds = (): void => {
-    writeData('creds', state.creds);
+    writeData(userId, 'creds', state.creds);
   };
 
   return { state, saveCreds };
 }
 
-export function clearSQLiteAuthState(): void {
-  delPrefixStmt.run('%');
-  console.log('[WA] Cleared SQLite auth state');
+export function clearSQLiteAuthState(userId: number): void {
+  delAllStmt.run(userId);
+  console.log(`[WA] Cleared SQLite auth state for user ${userId}`);
 }

--- a/server/src/whatsapp/contactStore.ts
+++ b/server/src/whatsapp/contactStore.ts
@@ -7,45 +7,38 @@ export interface WAContact {
   number: string;
 }
 
-let ioRef: SocketIOServer | null = null;
-
-// Only overwrite name if the new value is non-empty
 const upsertStmt = db.prepare(
-  `INSERT INTO wa_contacts (jid, number, name, synced) VALUES (?, ?, ?, 0)
-   ON CONFLICT(jid) DO UPDATE SET
+  `INSERT INTO wa_contacts (user_id, jid, number, name, synced) VALUES (?, ?, ?, ?, 0)
+   ON CONFLICT(user_id, jid) DO UPDATE SET
      number = excluded.number,
      name = CASE WHEN excluded.name != '' THEN excluded.name ELSE wa_contacts.name END`
 );
 
-const upsertMany = db.transaction((items: WAContact[]) => {
+const upsertMany = db.transaction((userId: number, items: WAContact[]) => {
   for (const item of items) {
-    upsertStmt.run(item.jid, item.number, item.name);
+    upsertStmt.run(userId, item.jid, item.number, item.name);
   }
 });
 
-export function setIO(io: SocketIOServer): void {
-  ioRef = io;
-}
-
-function getCounts(): { synced: number; buffered: number } {
+function getCounts(userId: number): { synced: number; buffered: number } {
   const row = db.prepare(
     `SELECT
        COUNT(CASE WHEN synced = 1 THEN 1 END) as synced,
        COUNT(CASE WHEN synced = 0 THEN 1 END) as buffered
-     FROM wa_contacts`
-  ).get() as { synced: number; buffered: number };
+     FROM wa_contacts WHERE user_id = ?`
+  ).get(userId) as { synced: number; buffered: number };
   return row;
 }
 
-function emitCount(): void {
-  if (ioRef) {
-    ioRef.emit('contacts:count', getCounts());
-  }
+function emitCount(userId: number, io: SocketIOServer): void {
+  io.to(`user:${userId}`).emit('contacts:count', getCounts(userId));
 }
 
 /** Buffer contacts from Baileys events (stored but not yet searchable) */
 export function bufferContacts(
-  items: Record<string, unknown>[]
+  userId: number,
+  items: Record<string, unknown>[],
+  io: SocketIOServer
 ): void {
   const toInsert: WAContact[] = [];
   for (const item of items) {
@@ -56,38 +49,38 @@ export function bufferContacts(
     toInsert.push({ jid, name, number });
   }
   if (toInsert.length > 0) {
-    upsertMany(toInsert);
+    upsertMany(userId, toInsert);
   }
-  emitCount();
+  emitCount(userId, io);
 }
 
 /** Flush buffer: mark all unsynced contacts as synced (makes them searchable) */
-export function flushBufferToStore(): { synced: number; buffered: number } {
-  db.prepare(`UPDATE wa_contacts SET synced = 1 WHERE synced = 0`).run();
-  const counts = getCounts();
-  emitCount();
+export function flushBufferToStore(userId: number, io: SocketIOServer): { synced: number; buffered: number } {
+  db.prepare(`UPDATE wa_contacts SET synced = 1 WHERE user_id = ? AND synced = 0`).run(userId);
+  const counts = getCounts(userId);
+  emitCount(userId, io);
   return counts;
 }
 
-export function searchContacts(query: string, limit = 20): WAContact[] {
+export function searchContacts(userId: number, query: string, limit = 20): WAContact[] {
   if (!query || query.length < 2) return [];
   const q = `%${query.toLowerCase()}%`;
   return db.prepare(
     `SELECT jid, name, number FROM wa_contacts
-     WHERE synced = 1 AND (LOWER(name) LIKE ? OR number LIKE ?)
+     WHERE user_id = ? AND synced = 1 AND (LOWER(name) LIKE ? OR number LIKE ?)
      LIMIT ?`
-  ).all(q, q, limit) as WAContact[];
+  ).all(userId, q, q, limit) as WAContact[];
 }
 
-export function clearContacts(): void {
-  db.prepare(`DELETE FROM wa_contacts`).run();
-  emitCount();
+export function clearContacts(userId: number, io: SocketIOServer): void {
+  db.prepare(`DELETE FROM wa_contacts WHERE user_id = ?`).run(userId);
+  emitCount(userId, io);
 }
 
-export function getContactCount(): number {
-  return (db.prepare(`SELECT COUNT(*) as c FROM wa_contacts WHERE synced = 1`).get() as { c: number }).c;
+export function getContactCount(userId: number): number {
+  return (db.prepare(`SELECT COUNT(*) as c FROM wa_contacts WHERE user_id = ? AND synced = 1`).get(userId) as { c: number }).c;
 }
 
-export function getBufferCount(): number {
-  return (db.prepare(`SELECT COUNT(*) as c FROM wa_contacts WHERE synced = 0`).get() as { c: number }).c;
+export function getBufferCount(userId: number): number {
+  return (db.prepare(`SELECT COUNT(*) as c FROM wa_contacts WHERE user_id = ? AND synced = 0`).get(userId) as { c: number }).c;
 }

--- a/server/src/whatsapp/sender.ts
+++ b/server/src/whatsapp/sender.ts
@@ -18,11 +18,13 @@ export async function executeBlast(
   contacts: Contact[],
   template: string,
   io: SocketIOServer,
-  blastId: number
+  blastId: number,
+  userId: number
 ): Promise<void> {
   let sent = 0;
   let failed = 0;
   const total = contacts.length;
+  const room = `user:${userId}`;
 
   const updateRecipient = db.prepare(
     "UPDATE blast_recipients SET status = ?, error = ?, rendered_message = ?, sent_at = datetime('now') WHERE id = (SELECT id FROM blast_recipients WHERE blast_id = ? AND number = ? AND status = 'pending' LIMIT 1)"
@@ -53,16 +55,16 @@ export async function executeBlast(
         } catch {
           failed++;
           updateRecipient.run('failed', errorMsg, message, blastId, number);
-          io.emit('blast:error', { number, name: variables.name || '', error: errorMsg });
+          io.to(room).emit('blast:error', { number, name: variables.name || '', error: errorMsg });
         }
       } else {
         failed++;
         updateRecipient.run('failed', errorMsg, message, blastId, number);
-        io.emit('blast:error', { number, name: variables.name || '', error: errorMsg });
+        io.to(room).emit('blast:error', { number, name: variables.name || '', error: errorMsg });
       }
     }
 
-    io.emit('blast:progress', { sent, failed, total });
+    io.to(room).emit('blast:progress', { sent, failed, total });
 
     // Rate limiting
     if ((i + 1) % BLAST_CONFIG.batchSize === 0 && i < contacts.length - 1) {
@@ -73,5 +75,5 @@ export async function executeBlast(
   }
 
   updateHistory.run(sent, failed, 'completed', blastId);
-  io.emit('blast:complete', { sent, failed, total });
+  io.to(room).emit('blast:complete', { sent, failed, total });
 }

--- a/server/src/whatsapp/session.ts
+++ b/server/src/whatsapp/session.ts
@@ -12,24 +12,42 @@ import { bufferContacts, clearContacts } from './contactStore.js';
 const MAX_RETRIES = 3;
 const WA_VERSION: [number, number, number] = [2, 3000, 1034195523];
 
-let sock: ReturnType<typeof makeWASocket> | null = null;
-let status: WAStatus = 'disconnected';
-let initializing = false;
-let retryCount = 0;
-
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function getSocket(): typeof sock {
-  return sock;
+interface UserSession {
+  sock: ReturnType<typeof makeWASocket> | null;
+  status: WAStatus;
+  initializing: boolean;
+  retryCount: number;
 }
 
-export function getStatus(): WAStatus {
-  return status;
+const sessions = new Map<number, UserSession>();
+
+function getSession(userId: number): UserSession {
+  let session = sessions.get(userId);
+  if (!session) {
+    session = { sock: null, status: 'disconnected', initializing: false, retryCount: 0 };
+    sessions.set(userId, session);
+  }
+  return session;
+}
+
+function emitToUser(io: SocketIOServer, userId: number, event: string, ...args: unknown[]): void {
+  io.to(`user:${userId}`).emit(event, ...args);
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function getSocket(userId: number): ReturnType<typeof makeWASocket> | null {
+  return sessions.get(userId)?.sock ?? null;
+}
+
+export function getStatus(userId: number): WAStatus {
+  return sessions.get(userId)?.status ?? 'disconnected';
 }
 
 /** Force Baileys to re-sync app state, which triggers contacts.upsert with saved names */
-export async function syncContacts(): Promise<void> {
-  if (!sock) throw new Error('WhatsApp not connected');
-  await sock.resyncAppState([
+export async function syncContacts(userId: number): Promise<void> {
+  const session = sessions.get(userId);
+  if (!session?.sock) throw new Error('WhatsApp not connected');
+  await session.sock.resyncAppState([
     'critical_block',
     'critical_unblock_low',
     'regular_high',
@@ -38,63 +56,65 @@ export async function syncContacts(): Promise<void> {
   ], false);
 }
 
-export async function initSession(io: SocketIOServer): Promise<void> {
-  if (initializing) {
-    console.log('[WA] Already initializing, skipping');
+export async function initSession(userId: number, io: SocketIOServer): Promise<void> {
+  const session = getSession(userId);
+
+  if (session.initializing) {
+    console.log(`[WA:${userId}] Already initializing, skipping`);
     return;
   }
 
-  if (sock) {
-    console.log('[WA] Closing existing socket before reinit');
-    sock.ev.removeAllListeners('connection.update');
-    sock.ev.removeAllListeners('creds.update');
-    sock.ev.removeAllListeners('messaging-history.set');
-    sock.ev.removeAllListeners('contacts.upsert');
-    sock.ev.removeAllListeners('contacts.update');
-    sock.end(undefined);
-    sock = null;
+  if (session.sock) {
+    console.log(`[WA:${userId}] Closing existing socket before reinit`);
+    session.sock.ev.removeAllListeners('connection.update');
+    session.sock.ev.removeAllListeners('creds.update');
+    session.sock.ev.removeAllListeners('messaging-history.set');
+    session.sock.ev.removeAllListeners('contacts.upsert');
+    session.sock.ev.removeAllListeners('contacts.update');
+    session.sock.end(undefined);
+    session.sock = null;
   }
 
-  initializing = true;
-  console.log('[WA] Initializing session... (attempt', retryCount + 1, ')');
+  session.initializing = true;
+  console.log(`[WA:${userId}] Initializing session... (attempt`, session.retryCount + 1, ')');
 
   try {
-    const { state, saveCreds } = useSQLiteAuthState();
+    const { state, saveCreds } = useSQLiteAuthState(userId);
 
-    sock = makeWASocket({
+    const sock = makeWASocket({
       auth: state,
       version: WA_VERSION,
       syncFullHistory: true,
     });
 
-    const currentSock = sock;
+    session.sock = sock;
 
-    currentSock.ev.on('connection.update', async (update) => {
+    sock.ev.on('connection.update', async (update) => {
       const { connection, lastDisconnect, qr } = update;
-      console.log('[WA] Connection update:', { connection, qr: !!qr });
+      console.log(`[WA:${userId}] Connection update:`, { connection, qr: !!qr });
 
       if (qr) {
-        status = 'qr_pending';
-        retryCount = 0;
+        session.status = 'qr_pending';
+        session.retryCount = 0;
         const qrDataUrl = await QRCode.toDataURL(qr);
-        io.emit('qr', qrDataUrl);
-        io.emit('status', status);
-        console.log('[WA] QR code emitted to client');
+        emitToUser(io, userId, 'qr', qrDataUrl);
+        emitToUser(io, userId, 'status', session.status);
+        console.log(`[WA:${userId}] QR code emitted to client`);
       }
 
       if (connection === 'open') {
-        status = 'connected';
-        initializing = false;
-        retryCount = 0;
-        io.emit('status', status);
-        console.log('[WA] Connected successfully');
+        session.status = 'connected';
+        session.initializing = false;
+        session.retryCount = 0;
+        emitToUser(io, userId, 'status', session.status);
+        console.log(`[WA:${userId}] Connected successfully`);
       }
 
       if (connection === 'close') {
         const reason = (lastDisconnect?.error as Boom)?.output?.statusCode;
-        console.log('[WA] Connection closed, reason:', reason);
-        sock = null;
-        initializing = false;
+        console.log(`[WA:${userId}] Connection closed, reason:`, reason);
+        session.sock = null;
+        session.initializing = false;
 
         const shouldClearAuth =
           reason === DisconnectReason.loggedOut ||
@@ -103,66 +123,69 @@ export async function initSession(io: SocketIOServer): Promise<void> {
           reason === DisconnectReason.connectionReplaced;
 
         if (shouldClearAuth) {
-          console.log('[WA] Got', reason, '— clearing auth state and retrying fresh');
-          clearSQLiteAuthState();
+          console.log(`[WA:${userId}] Got`, reason, '— clearing auth state and retrying fresh');
+          clearSQLiteAuthState(userId);
         }
 
-        retryCount++;
-        if (retryCount <= MAX_RETRIES) {
-          console.log('[WA] Retrying... (attempt', retryCount + 1, ')');
-          await initSession(io);
+        session.retryCount++;
+        if (session.retryCount <= MAX_RETRIES) {
+          console.log(`[WA:${userId}] Retrying... (attempt`, session.retryCount + 1, ')');
+          await initSession(userId, io);
         } else {
-          console.log('[WA] Max retries reached, giving up');
-          status = 'error';
-          retryCount = 0;
-          io.emit('status', status);
-          io.emit('wa:error', `Connection failed after ${MAX_RETRIES} attempts (code: ${reason}). Try again.`);
+          console.log(`[WA:${userId}] Max retries reached, giving up`);
+          session.status = 'error';
+          session.retryCount = 0;
+          emitToUser(io, userId, 'status', session.status);
+          emitToUser(io, userId, 'wa:error', `Connection failed after ${MAX_RETRIES} attempts (code: ${reason}). Try again.`);
         }
       }
     });
 
-    currentSock.ev.on('creds.update', saveCreds);
+    sock.ev.on('creds.update', saveCreds);
 
     // Initial contact sync comes via messaging-history.set in Baileys v6
-    currentSock.ev.on('messaging-history.set', ({ contacts: historyContacts }) => {
+    sock.ev.on('messaging-history.set', ({ contacts: historyContacts }) => {
       if (historyContacts && historyContacts.length > 0) {
-        bufferContacts(historyContacts as unknown as Record<string, unknown>[]);
+        bufferContacts(userId, historyContacts as unknown as Record<string, unknown>[], io);
       }
     });
 
-    currentSock.ev.on('contacts.upsert', (contacts) => {
-      bufferContacts(contacts as unknown as Record<string, unknown>[]);
+    sock.ev.on('contacts.upsert', (contacts) => {
+      bufferContacts(userId, contacts as unknown as Record<string, unknown>[], io);
     });
 
-    currentSock.ev.on('contacts.update', (contacts) => {
-      bufferContacts(contacts as unknown as Record<string, unknown>[]);
+    sock.ev.on('contacts.update', (contacts) => {
+      bufferContacts(userId, contacts as unknown as Record<string, unknown>[], io);
     });
   } catch (err) {
-    console.error('[WA] Init failed:', err);
-    initializing = false;
-    status = 'disconnected';
-    io.emit('status', status);
+    console.error(`[WA:${userId}] Init failed:`, err);
+    session.initializing = false;
+    session.status = 'disconnected';
+    emitToUser(io, userId, 'status', session.status);
   }
 }
 
-export async function disconnect(io: SocketIOServer): Promise<void> {
-  if (sock) {
-    sock.ev.removeAllListeners('connection.update');
-    sock.ev.removeAllListeners('creds.update');
-    sock.ev.removeAllListeners('messaging-history.set');
-    sock.ev.removeAllListeners('contacts.upsert');
-    sock.ev.removeAllListeners('contacts.update');
+export async function disconnect(userId: number, io: SocketIOServer): Promise<void> {
+  const session = sessions.get(userId);
+  if (session?.sock) {
+    session.sock.ev.removeAllListeners('connection.update');
+    session.sock.ev.removeAllListeners('creds.update');
+    session.sock.ev.removeAllListeners('messaging-history.set');
+    session.sock.ev.removeAllListeners('contacts.upsert');
+    session.sock.ev.removeAllListeners('contacts.update');
     try {
-      sock.end(undefined);
+      session.sock.end(undefined);
     } catch {
       // ignore — background tasks may throw on closed connection
     }
-    sock = null;
+    session.sock = null;
   }
-  clearSQLiteAuthState();
-  clearContacts();
-  initializing = false;
-  retryCount = 0;
-  status = 'disconnected';
-  io.emit('status', status);
+  clearSQLiteAuthState(userId);
+  clearContacts(userId, io);
+  if (session) {
+    session.initializing = false;
+    session.retryCount = 0;
+    session.status = 'disconnected';
+  }
+  emitToUser(io, userId, 'status', 'disconnected');
 }


### PR DESCRIPTION
## Summary

- **CRITICAL security fix**: WhatsApp sessions were shared globally — any user could see another user's WA status and send messages from their account
- Convert singleton WA session/auth/contacts to per-user `Map<number, UserSession>` keyed by user ID
- Use Socket.IO rooms (`user:<id>`) to scope all event emissions (QR, status, blast progress, contacts)
- Add `user_id` columns to `wa_auth` and `wa_contacts` tables with auto-migration (drops old tables since data re-syncs from WA)
- Blast execution validates session ownership — users can only send from their own connected WA

## Test plan

- [x] User A connects WA → User B sees "Disconnected" (not User A's status)
- [x] User B connects their own WA → gets their own QR code
- [x] User A's blast only uses User A's session
- [x] User B cannot access User A's contacts via search
- [x] Disconnecting User A doesn't affect User B
- [x] Existing blast history preserved (already user-scoped)

Closes #13